### PR TITLE
FEATURE: Approved notifications

### DIFF
--- a/app/controllers/discourse_code_review/code_review_controller.rb
+++ b/app/controllers/discourse_code_review/code_review_controller.rb
@@ -101,13 +101,50 @@ module DiscourseCodeReview
 
         DiscourseTagging.tag_topic_by_names(topic, Guardian.new(current_user), tags)
 
-        topic.add_moderator_post(
-          current_user,
-          nil,
-          bump: false,
-          post_type: Post.types[:small_action],
-          action_code: "approved"
+        old_highest_post_number = topic.highest_post_number
+        post =
+          topic.add_moderator_post(
+            current_user,
+            nil,
+            bump: false,
+            post_type: Post.types[:small_action],
+            action_code: "approved"
+          )
+
+        PostTiming.pretend_read(
+          topic.id,
+          old_highest_post_number,
+          post.post_number
         )
+
+        Notification.transaction do
+          destroyed_notifications =
+            topic.user.notifications
+              .where(
+                notification_type: Notification.types[:code_review_commit_approved],
+              )
+              .where('created_at > ?', 6.hours.ago)
+              .destroy_all
+
+          previous_approved =
+            destroyed_notifications.inject(0) do |sum, notification|
+              sum + JSON.parse(notification.data)['num_approved_commits'].to_i
+            end
+
+          if previous_approved == 0
+            topic.user.notifications.create(
+              notification_type: Notification.types[:code_review_commit_approved],
+              topic_id: topic.id,
+              post_number: post.post_number,
+              data: {num_approved_commits: 1}.to_json
+            )
+          else
+            topic.user.notifications.create(
+              notification_type: Notification.types[:code_review_commit_approved],
+              data: {num_approved_commits: previous_approved + 1}.to_json
+            )
+          end
+        end
 
         if SiteSetting.code_review_auto_unassign_on_approve && topic.user.staff?
           DiscourseEvent.trigger(:unassign_topic, topic, current_user)

--- a/assets/javascripts/discourse/activity-route-map.js.es6
+++ b/assets/javascripts/discourse/activity-route-map.js.es6
@@ -1,0 +1,7 @@
+export default {
+  resource: "user.userActivity",
+  map() {
+    this.route("approval-given");
+    this.route("approval-pending");
+  }
+};

--- a/assets/javascripts/discourse/routes/user-activity-approval-given.js.es6
+++ b/assets/javascripts/discourse/routes/user-activity-approval-given.js.es6
@@ -1,0 +1,9 @@
+import UserTopicListRoute from "discourse/routes/user-topic-list";
+
+export default UserTopicListRoute.extend({
+  model: function() {
+    return this.store.findFiltered("topicList", {
+      filter: `topics/approval-given/${this.modelFor("user").get("username_lower")}`
+    });
+  }
+});

--- a/assets/javascripts/discourse/routes/user-activity-approval-pending.js.es6
+++ b/assets/javascripts/discourse/routes/user-activity-approval-pending.js.es6
@@ -1,0 +1,9 @@
+import UserTopicListRoute from "discourse/routes/user-topic-list";
+
+export default UserTopicListRoute.extend({
+  model: function() {
+    return this.store.findFiltered("topicList", {
+      filter: `topics/approval-pending/${this.modelFor("user").get("username_lower")}`
+    });
+  }
+});

--- a/assets/javascripts/discourse/templates/connectors/user-activity-bottom/commit-activity-link.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-activity-bottom/commit-activity-link.hbs
@@ -1,0 +1,10 @@
+<li>
+  {{#link-to 'userActivity.approval-given'}}
+    {{i18n 'code_review.approval_given'}}
+  {{/link-to}}
+</li>
+<li>
+  {{#link-to 'userActivity.approval-pending'}}
+    {{i18n 'code_review.approval_pending'}}
+  {{/link-to}}
+</li>

--- a/assets/javascripts/discourse/widgets/code-review-commit-approved-notification-item.js.es6
+++ b/assets/javascripts/discourse/widgets/code-review-commit-approved-notification-item.js.es6
@@ -1,0 +1,21 @@
+import { createWidgetFrom } from "discourse/widgets/widget";
+import { DefaultNotificationItem } from "discourse/widgets/default-notification-item";
+import { replaceIcon } from "discourse-common/lib/icon-library";
+
+replaceIcon("notification.code_review_commit_approved", "check");
+
+createWidgetFrom(DefaultNotificationItem, "code-review-commit-approved-notification-item", {
+  title() {
+    return I18n.t("notifications.code_review.commit_approved.title");
+  },
+
+  text(notificationName, data) {
+    const num_approved_commits = data.num_approved_commits;
+
+    if (num_approved_commits == 1) {
+      return I18n.t("notifications.code_review.commit_approved.one");
+    } else {
+      return I18n.t("notifications.code_review.commit_approved.many", { num_approved_commits });
+    }
+  }
+});

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -17,3 +17,5 @@ en:
       followup:
         title: "Follow up commit"
         label: "Follow Up"
+      approval_given: "Approval Given"
+      approval_pending: "Approval Pending"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4,6 +4,12 @@ en:
       approved: "Approved"
       followup: "Follow Up"
       followed_up: "Followed Up"
+    notifications:
+      code_review:
+        commit_approved:
+          one: "Your commit was approved"
+          many: "{{num_approved_commits}} of your commits were approved"
+          title: "commit approved"
     code_review:
       approve:
         title: "Approve commit"

--- a/plugin.rb
+++ b/plugin.rb
@@ -121,6 +121,9 @@ after_initialize do
   end
 
   Discourse::Application.routes.append do
+    get '/topics/approval-given/:username' => 'list#approval_given', as: :topics_approval_given
+    get '/topics/approval-pending/:username' => 'list#approval_pending', as: :topics_approval_pending
+
     mount ::DiscourseCodeReview::Engine, at: '/code-review'
   end
 
@@ -135,6 +138,24 @@ after_initialize do
     unless post.topic.custom_fields[DiscourseCodeReview::CommitHash].present? && post.post_number == 1
       doc = DiscourseCodeReview::Importer.new(nil).auto_link_commits(post.raw, doc)[2]
     end
+  end
+
+  add_to_class(:list_controller, :approval_given) do
+    respond_with_list(
+      TopicQuery.new(
+        current_user,
+        tags: [SiteSetting.code_review_approved_tag]
+      ).list_topics_by(current_user)
+    )
+  end
+
+  add_to_class(:list_controller, :approval_pending) do
+    respond_with_list(
+      TopicQuery.new(
+        current_user,
+        tags: [SiteSetting.code_review_pending_tag]
+      ).list_topics_by(current_user)
+    )
   end
 end
 

--- a/spec/requests/discourse_code_review/code_review_controller_spec.rb
+++ b/spec/requests/discourse_code_review/code_review_controller_spec.rb
@@ -10,7 +10,7 @@ describe DiscourseCodeReview::CodeReviewController do
   end
 
   context '.approve' do
-    it 'allows you to approve your own commit if enabled' do
+    it 'doesn\'t allow you to approve your own commit if disabled' do
 
       SiteSetting.code_review_allow_self_approval = false
 


### PR DESCRIPTION
These changes add approved notifications for commit authors and placate the pesky unread indicator for everyone else.

This PR relies on changes to discourse core: https://github.com/discourse/discourse/pull/7725 and https://github.com/discourse/discourse/pull/7727