### PR TITLE
FIX: Rename overridden title method.

### DIFF
--- a/assets/javascripts/discourse/widgets/code-review-commit-approved-notification-item.js.es6
+++ b/assets/javascripts/discourse/widgets/code-review-commit-approved-notification-item.js.es6
@@ -8,7 +8,7 @@ createWidgetFrom(
   DefaultNotificationItem,
   "code-review-commit-approved-notification-item",
   {
-    title() {
+    notificationTitle() {
       return I18n.t("notifications.code_review.commit_approved.title");
     },
 


### PR DESCRIPTION
Related to discourse/discourse#7840.