### PR TITLE
FEATURE: Send only regular posts to GitHub

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -124,7 +124,7 @@ after_initialize do
       hash = topic&.custom_fields[DiscourseCodeReview::COMMIT_HASH]
       user = post.user
 
-      if post.post_number > 1 && !post.whisper? && post.raw.present? && topic && hash && user
+      if post.post_number > 1 && post.post_type == Post.types[:regular] && post.raw.present? && topic && hash && user
         if !post.custom_fields[DiscourseCodeReview::GITHUB_ID]
           fields = post.reply_to_post&.custom_fields || {}
           path = fields[DiscourseCodeReview::COMMENT_PATH]

--- a/spec/discourse_code_review/lib/github_pr_syncer_spec.rb
+++ b/spec/discourse_code_review/lib/github_pr_syncer_spec.rb
@@ -547,6 +547,7 @@ describe DiscourseCodeReview::GithubPRSyncer do
       fab!(:post) { Fabricate(:post, topic: topic, post_type: Post.types[:whisper]) }
 
       it "does not send the post to github" do
+        pr_service.expects(:create_issue_comment).never
         syncer.mirror_pr_post(post)
       end
     end
@@ -555,6 +556,7 @@ describe DiscourseCodeReview::GithubPRSyncer do
       fab!(:post) { Fabricate(:post, topic: topic, post_type: Post.types[:small_action]) }
 
       it "does not send the post to github" do
+        pr_service.expects(:create_issue_comment).never
         syncer.mirror_pr_post(post)
       end
     end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -170,6 +170,26 @@ describe DiscourseCodeReview do
           expect(client.call[:body]).to include(user.username)
         end
       end
+
+      context "when reply is a whisper" do
+        before { reply.post_type = Post.types[:whisper] }
+
+        it "does not send the reply to github" do
+          client.expects(:create_commit_comment).never
+
+          DiscourseCodeReview.sync_post_to_github(client, reply)
+        end
+      end
+
+      context "when reply is a small action" do
+        before { reply.post_type = Post.types[:small_action] }
+
+        it "does not send the reply to github" do
+          client.expects(:create_commit_comment).never
+
+          DiscourseCodeReview.sync_post_to_github(client, reply)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
`DiscourseCodeReview::GithubPRSyncer#mirror_pr_post` already behaved this way.
This PR updates `DiscourseCodeReview#sync_post_to_github`.