### PR TITLE
FIX: Don't mirror PR if the post is from a PM

### DIFF
--- a/lib/discourse_code_review/github_pr_syncer.rb
+++ b/lib/discourse_code_review/github_pr_syncer.rb
@@ -121,6 +121,7 @@ module DiscourseCodeReview
       user = post.user
 
       conditions = [
+        topic.regular?,
         post.post_number > 1,
         post.post_type == Post.types[:regular],
         post.custom_fields[GITHUB_NODE_ID].nil?

--- a/spec/lib/github_pr_syncer_spec.rb
+++ b/spec/lib/github_pr_syncer_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DiscourseCodeReview::GithubPRSyncer do
+  it 'does nothing if the topic is a PM' do
+    pm_post = Fabricate(:post, post_number: 2, topic: Fabricate(:private_message_topic))
+
+    syncer = described_class.new(nil, nil)
+
+    expect(syncer.mirror_pr_post(pm_post)).to be_nil
+  end
+end


### PR DESCRIPTION
`topic.category` is always `nil` if the topic is a PM.