### PR TITLE
FIX: Don't try to sync a commit if it's not present in the main repo.

### DIFF
--- a/lib/discourse_code_review/importer.rb
+++ b/lib/discourse_code_review/importer.rb
@@ -53,6 +53,7 @@ module DiscourseCodeReview
 
     def sync_commit_sha(commit_sha)
       commit = github_repo.commit(commit_sha)
+      return if commit.nil?
       sync_commit(commit)
     end
 


### PR DESCRIPTION
Example [here](https://github.com/discourse/discourse/pull/10709)

If someone opens a PR to merge a fork's commit into the main repo, and someone comments on the commit instead of the PR, the plugin won't be able to find it.