### PR TITLE
FEATURE: Continue reviewing in same category, even if muted

### DIFF
--- a/app/controllers/discourse_code_review/code_review_controller.rb
+++ b/app/controllers/discourse_code_review/code_review_controller.rb
@@ -115,7 +115,8 @@ module DiscourseCodeReview
           SELECT category_id
           FROM category_users
           WHERE user_id = :user_id AND
-            notification_level = :notification_level
+            notification_level = :notification_level AND
+            category_id <> :requested_category_id
         )
       SQL
 
@@ -138,7 +139,8 @@ module DiscourseCodeReview
         .where(
           category_filter_sql,
           user_id: current_user.id,
-          notification_level: CategoryUser.notification_levels[:muted]
+          notification_level: CategoryUser.notification_levels[:muted],
+          requested_category_id: category_id
         )
         .order(
           'case when cr.expires_at IS NULL then 0 else 1 end asc',


### PR DESCRIPTION
If you had all code review categories muted, then previously you would be taken to `/latest` every time you review a commit. Now it will continue in the same category, even if it's muted.