### PR TITLE
FEATURE: allow removal of followup button

### DIFF
--- a/app/controllers/discourse_code_review/code_review_controller.rb
+++ b/app/controllers/discourse_code_review/code_review_controller.rb
@@ -81,6 +81,10 @@ module DiscourseCodeReview
     end
 
     def followup
+      if !SiteSetting.code_review_allow_manual_followup
+        raise Discourse::InvalidAccess
+      end
+
       topic = Topic.find_by(id: params[:topic_id])
 
       State::CommitApproval.followup(

--- a/assets/javascripts/discourse/initializers/init-code-review.js.es6
+++ b/assets/javascripts/discourse/initializers/init-code-review.js.es6
@@ -68,7 +68,11 @@ function initialize(api) {
     );
   }
 
-  function allowFollowup(topic, siteSettings) {
+  function allowFollowupButton(topic, siteSettings) {
+    if (!siteSettings.code_review_allow_manual_followup) {
+      return false;
+    }
+
     const approvedTag = siteSettings.code_review_approved_tag;
     const pendingTag = siteSettings.code_review_pending_tag;
     const followupTag = siteSettings.code_review_followup_tag;
@@ -142,7 +146,7 @@ function initialize(api) {
     displayed() {
       return (
         this.get("currentUser.staff") &&
-        allowFollowup(this.topic, this.siteSettings)
+        allowFollowupButton(this.topic, this.siteSettings)
       );
     },
   });

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5,6 +5,7 @@ en:
     code_review_sync_to_github: "REQUIRES: code_review_github_token, should comments here be sent to github?"
     code_review_catch_up_commits: "When a new repo is added create this number of topics for old commits"
     code_review_allow_private_clone: "REQUIRES: code_review_github_token, will clone the repos as the associated user, this safeguard is in place to disable cloning of private repos on public sites."
+    code_review_allow_manual_followup: "Allow follow up button on commits"
     code_review_pending_tag: "Tag to apply to pending commits"
     code_review_followup_tag: "Tag to apply to follow up commits"
     code_review_approved_tag: "Tag to apply to approved commits"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,9 @@ plugins:
   code_review_sync_to_github: false
   code_review_catch_up_commits: 10
   code_review_allow_private_clone: false
+  code_review_allow_manual_followup:
+    client: true
+    default: true
   code_review_pending_tag:
     client: true
     default: "pending"

--- a/spec/requests/discourse_code_review/code_review_controller_spec.rb
+++ b/spec/requests/discourse_code_review/code_review_controller_spec.rb
@@ -275,6 +275,13 @@ describe DiscourseCodeReview::CodeReviewController do
         expect(commit.topic.tags.pluck(:name)).to include("hi", SiteSetting.code_review_followup_tag)
       end
 
+      it 'gives invalid access when manual follow up is disabled' do
+        SiteSetting.code_review_allow_manual_followup = false
+        commit = create_post(raw: "this is a fake commit", tags: ["hi", SiteSetting.code_review_pending_tag])
+        post '/code-review/followup.json', params: { topic_id: commit.topic_id }
+        expect(response.status).to eq(403)
+      end
+
       it 'does nothing when following-up already followed-up posts' do
         commit = create_post(raw: "this is a fake commit", tags: ["hi", SiteSetting.code_review_pending_tag])
 


### PR DESCRIPTION
The followup button can be handy in many cases, but it can also create lots
of broken windows where commits sit in limbo for many months or even years.


This allows opting out of this button by setting
`code_review_allow_manual_followup` to false in site setting

Default behavior is not impacted