### PR TITLE
FEATURE: Allow for less restrictive follow up commit mentioning

### DIFF
--- a/lib/discourse_code_review/github_repo.rb
+++ b/lib/discourse_code_review/github_repo.rb
@@ -165,6 +165,7 @@ module DiscourseCodeReview
       result = []
 
       git_repo.commit(ref).message.lines.each do |line|
+        next if line =~ /^revert\b/i
         data = line[/follow.*?(\h{7,})/i, 1]
         result << data if data
       end

--- a/lib/discourse_code_review/github_repo.rb
+++ b/lib/discourse_code_review/github_repo.rb
@@ -162,10 +162,16 @@ module DiscourseCodeReview
     end
 
     def followees(ref)
-      git_repo
-        .trailers(ref)
-        .select { |x| x.first == 'Follow-up-to' }
-        .map(&:second)
+      result = []
+
+      git_repo.commit(ref).message.lines.each do |line|
+        data = line.match(/follow.*?([a-z0-9]{7,})/i)
+        if data.present?
+          result << data[1]
+        end
+      end
+
+      result
     end
 
     def path

--- a/lib/discourse_code_review/github_repo.rb
+++ b/lib/discourse_code_review/github_repo.rb
@@ -165,10 +165,8 @@ module DiscourseCodeReview
       result = []
 
       git_repo.commit(ref).message.lines.each do |line|
-        data = line.match(/follow.*?([a-z0-9]{7,})/i)
-        if data.present?
-          result << data[1]
-        end
+        data = line[/follow.*?(\h{7,})/i, 1]
+        result << data if data
       end
 
       result

--- a/lib/discourse_code_review/github_repo.rb
+++ b/lib/discourse_code_review/github_repo.rb
@@ -164,8 +164,8 @@ module DiscourseCodeReview
     def followees(ref)
       result = []
 
-      git_repo.commit(ref).message.lines.each do |line|
-        next if line =~ /^revert\b/i
+      git_repo.commit(ref).message.lines.each_with_index do |line, index|
+        next if index == 0 && line =~ /^revert\b/i
         data = line[/follow.*?(\h{7,})/i, 1]
         result << data if data
       end

--- a/lib/discourse_code_review/state/commit_topics.rb
+++ b/lib/discourse_code_review/state/commit_topics.rb
@@ -110,23 +110,23 @@ module DiscourseCodeReview::State::CommitTopics
               value: commit[:hash]
             )
 
-            followee_topics =
-              Topic
-                .where(
-                  id:
-                    TopicCustomField
-                      .where(
-                        name: DiscourseCodeReview::COMMIT_HASH,
-                        value: followees,
-                      )
-                      .select(:topic_id)
-                )
+            if followees.present?
+              followee_topics =
+                Topic
+                  .where(
+                    id:
+                      TopicCustomField
+                        .where(name: DiscourseCodeReview::COMMIT_HASH)
+                        .where('value SIMILAR TO ?', "(#{followees.join('|')})%")
+                        .select(:topic_id)
+                  )
 
-            followee_topics.each do |followee_topic|
-              DiscourseCodeReview::State::CommitApproval.followed_up(
-                followee_topic,
-                post.topic,
-              )
+              followee_topics.each do |followee_topic|
+                DiscourseCodeReview::State::CommitApproval.followed_up(
+                  followee_topic,
+                  post.topic,
+                )
+              end
             end
 
             topic = post.topic

--- a/spec/discourse_code_review/lib/importer_spec.rb
+++ b/spec/discourse_code_review/lib/importer_spec.rb
@@ -135,5 +135,31 @@ module DiscourseCodeReview
 
       expect(followee.tags.pluck(:name)).to include(SiteSetting.code_review_approved_tag)
     end
+
+    it "approves followed-up topics with partial hashes" do
+      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil)
+
+      SiteSetting.code_review_enabled = true
+
+      commit = {
+        subject: "hello world",
+        body: "this is the body",
+        email: "sam@sam.com",
+        github_login: "sam",
+        github_id: "111",
+        date: 1.day.ago,
+        diff: "```\nwith a diff",
+        hash: "5ff6c10320cab7ef82ecda40c57cfb9e539b7e72"
+      }
+
+      followee = Topic.find(Importer.new(repo).import_commit(commit))
+
+      expect(followee.tags.pluck(:name)).not_to include(SiteSetting.code_review_approved_tag)
+
+      commit[:hash] = "dbfb2a1e11b6a4f33d35b26885193774e7ab9362"
+      follower = Topic.find(Importer.new(repo).import_commit(commit))
+
+      expect(followee.tags.pluck(:name)).to include(SiteSetting.code_review_approved_tag)
+    end
   end
 end


### PR DESCRIPTION
For example, if word follow is found before a commit hash, the system
will automatically interpret it as a follow up commit. Before this, a
proper Git trailer was needed such as:

> Follow-up-to: 5ff6c10320cab7ef82ecda40c57cfb9e539b7e72

Now, the whole message body can be just:

> Minor follow-up bug fix for 5ff6c10.