### PR TITLE
FIX: Make sure approvers are unique

### DIFF
--- a/lib/discourse_code_review/state/commit_approval.rb
+++ b/lib/discourse_code_review/state/commit_approval.rb
@@ -190,6 +190,7 @@ module DiscourseCodeReview::State::CommitApproval
         approvers_string =
           approvers
             .map(&:username)
+            .uniq
             .to_sentence
 
         raw_parts << "approved by #{approvers_string}. It was"

--- a/spec/discourse_code_review/lib/state/commit_approval_spec.rb
+++ b/spec/discourse_code_review/lib/state/commit_approval_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module DiscourseCodeReview
+  describe State::CommitApproval do
+    fab!(:topic) { Fabricate(:topic) }
+    fab!(:pr) {
+      DiscourseCodeReview::PullRequest.new(
+        owner: "owner",
+        name: "name",
+        issue_number: 101,
+      )
+    }
+    fab!(:approver) { Fabricate(:user) }
+    fab!(:merged_by) { Fabricate(:user) }
+
+    describe "#ensure_pr_merge_info_post" do
+      it "does not consider duplicate approvers" do
+        post = State::CommitApproval.approve(topic, [approver, merged_by] * 2, pr: pr, merged_by: merged_by)
+        expect(post.raw).to eq("This commit appears in [#101](https://github.com/owner/name/pull/101) which was approved by #{approver.username} and #{merged_by.username}. It was merged by #{merged_by.username}.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
GitHub allows the same user to approve the same pull request multiple
times.