### PR TITLE
DEV: Set the bumped_at time whenever we create a new topic

### DIFF
--- a/lib/discourse_code_review/state/helpers.rb
+++ b/lib/discourse_code_review/state/helpers.rb
@@ -25,6 +25,7 @@ module DiscourseCodeReview::State::Helpers
               topic = post.topic
               topic.custom_fields = custom_fields
               topic.save_custom_fields
+              topic.update(bumped_at: Time.zone.now)
 
               yield post if block_given?
             end


### PR DESCRIPTION
This ensures that old commits that are newly applied at shown in topic
lists as expected.