### PR TITLE
Make API Key secret

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,7 +19,9 @@ plugins:
   code_review_unmerged_tag: "unmerged"
   code_review_commit_tag: "commit"
   code_review_pull_request_tag: "pull-request"
-  code_review_github_webhook_secret: ""
+  code_review_github_webhook_secret: 
+    default: ""
+    secret: true
   code_review_allow_self_approval:
     client: true
     default: false


### PR DESCRIPTION
Don't display API Key by default, require logged click