### PR TITLE
DEV: Print debug info if repo_name is blank

### DIFF
--- a/app/controllers/discourse_code_review/code_review_controller.rb
+++ b/app/controllers/discourse_code_review/code_review_controller.rb
@@ -34,6 +34,7 @@ module DiscourseCodeReview
 
       repo = params["repository"]
       repo_name = repo["full_name"] if repo
+      Rails.logger.warn("repo_name is blank. #{params.to_json}") if repo_name.blank?
 
       if type == "commit_comment"
         commit_sha = params["comment"]["commit_id"]


### PR DESCRIPTION
There were reports of `code_review_sync_commits` being called with a blank of `repo_name`, but none of the GitHub webhook logs show any payload with an empty repo `full_name`.