### PR TITLE
FIX: find existing category when a repository is moved/renamed

### DIFF
--- a/app/jobs/regular/code_review_sync_commit_comments.rb
+++ b/app/jobs/regular/code_review_sync_commit_comments.rb
@@ -3,7 +3,7 @@
 module Jobs
   class CodeReviewSyncCommitComments < ::Jobs::Base
     def execute(args)
-      repo_name, commit_sha = args.values_at(:repo_name, :commit_sha)
+      repo_name, commit_sha, repo_id = args.values_at(:repo_name, :commit_sha, :repo_id)
 
       unless repo_name.kind_of?(String)
         raise Discourse::InvalidParameters.new(:repo_name)
@@ -15,7 +15,7 @@ module Jobs
 
       client = DiscourseCodeReview.octokit_client
       github_commit_querier = DiscourseCodeReview.github_commit_querier
-      repo = DiscourseCodeReview::GithubRepo.new(repo_name, client, github_commit_querier)
+      repo = DiscourseCodeReview::GithubRepo.new(repo_name, client, github_commit_querier, repo_id: repo_id)
       importer = DiscourseCodeReview::Importer.new(repo)
 
       importer.sync_commit_sha(commit_sha)

--- a/app/jobs/regular/code_review_sync_commits.rb
+++ b/app/jobs/regular/code_review_sync_commits.rb
@@ -7,12 +7,12 @@ module Jobs
         raise Discourse::InvalidParameters.new(:repo_name)
       end
 
-      repo_name = args[:repo_name]
+      repo_name, repo_id = args.values_at(:repo_name, :repo_id)
 
       client = DiscourseCodeReview.octokit_client
       github_commit_querier = DiscourseCodeReview.github_commit_querier
 
-      repo = DiscourseCodeReview::GithubRepo.new(repo_name, client, github_commit_querier)
+      repo = DiscourseCodeReview::GithubRepo.new(repo_name, client, github_commit_querier, repo_id: repo_id)
       importer = DiscourseCodeReview::Importer.new(repo)
 
       importer.sync_merged_commits do |commit_hash|

--- a/lib/discourse_code_review/github_pr_syncer.rb
+++ b/lib/discourse_code_review/github_pr_syncer.rb
@@ -11,7 +11,7 @@ module DiscourseCodeReview
       @user_syncer = user_syncer
     end
 
-    def sync_pull_request(repo_name, issue_number)
+    def sync_pull_request(repo_name, issue_number, repo_id: nil)
       owner, name = repo_name.split('/', 2)
 
       pr =
@@ -26,7 +26,8 @@ module DiscourseCodeReview
       category =
         State::GithubRepoCategories
           .ensure_category(
-            repo_name: repo_name
+            repo_name: repo_name,
+            repo_id: repo_id
           )
 
       url =
@@ -70,9 +71,9 @@ module DiscourseCodeReview
         end
     end
 
-    def sync_associated_pull_requests(repo_name, git_commit)
+    def sync_associated_pull_requests(repo_name, git_commit, repo_id: nil)
       pr_service.associated_pull_requests(repo_name, git_commit).each do |pr|
-        sync_pull_request(repo_name, pr.issue_number)
+        sync_pull_request(repo_name, pr.issue_number, repo_id: repo_id)
       end
     end
 

--- a/lib/discourse_code_review/github_repo.rb
+++ b/lib/discourse_code_review/github_repo.rb
@@ -2,16 +2,17 @@
 
 module DiscourseCodeReview
   class GithubRepo
-    attr_reader :name, :octokit_client
+    attr_reader :name, :octokit_client, :repo_id
 
     LAST_COMMIT = 'last commit'
     MAX_DIFF_LENGTH = 8000
 
-    def initialize(name, octokit_client, commit_querier)
+    def initialize(name, octokit_client, commit_querier, repo_id: nil)
       @owner, @repo = name.split('/')
       @name = name
       @octokit_client = octokit_client
       @commit_querier = commit_querier
+      @repo_id = repo_id
     end
 
     def clean_name

--- a/lib/discourse_code_review/importer.rb
+++ b/lib/discourse_code_review/importer.rb
@@ -36,7 +36,8 @@ module DiscourseCodeReview
     def category_id
       @category_id ||=
         State::GithubRepoCategories.ensure_category(
-          repo_name: github_repo.name
+          repo_name: github_repo.name,
+          repo_id: github_repo.repo_id
         ).id
     end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -24,8 +24,8 @@ register_svg_icon 'history'
 
 require_dependency 'auth/github_authenticator'
 require_dependency 'lib/staff_constraint'
-module HackGithubAuthenticator
 
+module HackGithubAuthenticator
   def after_authenticate(auth_token, existing_account: nil)
     result = super(auth_token, existing_account: existing_account)
 

--- a/spec/discourse_code_review/lib/state/github_repo_categories_spec.rb
+++ b/spec/discourse_code_review/lib/state/github_repo_categories_spec.rb
@@ -5,13 +5,39 @@ require "rails_helper"
 describe DiscourseCodeReview::State::GithubRepoCategories do
   it "can create a new category" do
     expect {
-      c = described_class.ensure_category(repo_name: "repo-name")
+      c = described_class.ensure_category(repo_name: "repo-name", repo_id: 242)
       expect(c.name).to eq("repo-name")
+      expect(c.custom_fields[DiscourseCodeReview::State::GithubRepoCategories::GITHUB_REPO_ID]).to eq("242")
       expect(c.custom_fields[DiscourseCodeReview::State::GithubRepoCategories::GITHUB_REPO_NAME]).to eq("repo-name")
     }.to change { Category.count }.by(1)
   end
 
   it "can use an existing category" do
+    c = Fabricate(:category, name: "repo-name")
+    c.custom_fields[DiscourseCodeReview::State::GithubRepoCategories::GITHUB_REPO_NAME] = "repo-name"
+    c.save_custom_fields
+    expect {
+      c = described_class.ensure_category(repo_name: "repo-name", repo_id: 242)
+      expect(c.name).to eq("repo-name")
+    }.to_not change { Category.count }
+    # updates repository ID in custom field
+    expect(c.custom_fields[DiscourseCodeReview::State::GithubRepoCategories::GITHUB_REPO_ID]).to eq("242")
+  end
+
+  it "can use an existing category based on repository ID" do
+    c = Fabricate(:category, name: "repo-name")
+    c.custom_fields[DiscourseCodeReview::State::GithubRepoCategories::GITHUB_REPO_ID] = "242"
+    c.custom_fields[DiscourseCodeReview::State::GithubRepoCategories::GITHUB_REPO_NAME] = "repo-name"
+    c.save_custom_fields
+    expect {
+      c = described_class.ensure_category(repo_name: "new-repo-name", repo_id: 242)
+      expect(c.name).to eq("repo-name")
+    }.to_not change { Category.count }
+    # updates repository name in custom field
+    expect(c.custom_fields[DiscourseCodeReview::State::GithubRepoCategories::GITHUB_REPO_NAME]).to eq("new-repo-name")
+  end
+
+  it "does not break when repository ID is not present" do
     c = Fabricate(:category, name: "repo-name")
     c.custom_fields[DiscourseCodeReview::State::GithubRepoCategories::GITHUB_REPO_NAME] = "repo-name"
     c.save_custom_fields


### PR DESCRIPTION
When a repository is moved or renamed the plugin creates a new category on subsequent commit because the category is identified by repository full_name (`{github_org}/{github_repo}`). This commit links the category to repository ID so that when the repository full_name is changed it can find the category via repository ID. It also updates the repository full_name to reflect new location/name.