### PR TITLE
FIX: only create new category when repo_id is present

### DIFF
--- a/spec/discourse_code_review/lib/github_pr_syncer_spec.rb
+++ b/spec/discourse_code_review/lib/github_pr_syncer_spec.rb
@@ -100,7 +100,8 @@ describe DiscourseCodeReview::GithubPRSyncer do
 
   fab!(:category) do
     DiscourseCodeReview::State::GithubRepoCategories.ensure_category(
-      repo_name: 'owner/name'
+      repo_name: 'owner/name',
+      repo_id: '24'
     )
   end
 

--- a/spec/discourse_code_review/lib/github_repo_spec.rb
+++ b/spec/discourse_code_review/lib/github_repo_spec.rb
@@ -53,7 +53,7 @@ module DiscourseCodeReview
       end
 
       it "does not explode" do
-        repo = GithubRepo.new('fake_repo/fake_repo', nil, nil)
+        repo = GithubRepo.new('fake_repo/fake_repo', nil, nil, repo_id: 24)
         repo.stubs(:default_branch).returns("origin/master")
         repo.path = checkout_path
         repo.last_commit = nil
@@ -76,7 +76,7 @@ module DiscourseCodeReview
       end
 
       it "truncates the diff" do
-        repo = GithubRepo.new('fake_repo/fake_repo', nil, nil)
+        repo = GithubRepo.new('fake_repo/fake_repo', nil, nil, repo_id: 24)
         repo.stubs(:default_branch).returns("origin/master")
         repo.path = checkout_path
         repo.last_commit = nil
@@ -108,7 +108,7 @@ module DiscourseCodeReview
         sha = `git rev-parse HEAD`.strip
       end
 
-      repo = GithubRepo.new('fake_repo/fake_repo', nil, nil)
+      repo = GithubRepo.new('fake_repo/fake_repo', nil, nil, repo_id: 24)
       repo.stubs(:default_branch).returns("origin/master")
       repo.path = checkout_path
 
@@ -130,7 +130,7 @@ module DiscourseCodeReview
         sha = `git rev-parse HEAD`.strip
       end
 
-      repo = GithubRepo.new('fake_repo/fake_repo', nil, nil)
+      repo = GithubRepo.new('fake_repo/fake_repo', nil, nil, repo_id: 24)
       repo.stubs(:default_branch).returns("origin/master")
       repo.path = checkout_path
 

--- a/spec/discourse_code_review/lib/importer_spec.rb
+++ b/spec/discourse_code_review/lib/importer_spec.rb
@@ -9,7 +9,7 @@ module DiscourseCodeReview
     end
 
     let(:parent_category) { Fabricate(:category) }
-    let(:repo) { GithubRepo.new("discourse/discourse", Octokit::Client.new, nil) }
+    let(:repo) { GithubRepo.new("discourse/discourse", Octokit::Client.new, nil, repo_id: 24) }
 
     it "creates categories with a description" do
       category = Category.find_by(id: Importer.new(repo).category_id)
@@ -41,7 +41,7 @@ module DiscourseCodeReview
       # lets muck stuff up first ... and create a dupe category
       Category.create!(name: 'discourse', user: Discourse.system_user)
 
-      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil)
+      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil, repo_id: 24)
       id = Importer.new(repo).category_id
 
       expect(id).to be > 0
@@ -49,7 +49,7 @@ module DiscourseCodeReview
     end
 
     it "can cleanly associate old commits" do
-      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil)
+      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil, repo_id: 24)
 
       diff = "```\nwith a diff"
 
@@ -84,7 +84,7 @@ module DiscourseCodeReview
 
     it "can handle complex imports" do
 
-      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil)
+      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil, repo_id: 24)
 
       diff = "```\nwith a diff"
 
@@ -113,7 +113,7 @@ module DiscourseCodeReview
     end
 
     it "approves followed-up topics" do
-      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil)
+      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil, repo_id: 24)
       repo.expects(:default_branch_contains?).with('a91843f0dc7b97e700dc85505404eafd62b7f8c5').returns(true)
       repo.expects(:followees).with('a91843f0dc7b97e700dc85505404eafd62b7f8c5').returns([])
       repo.expects(:default_branch_contains?).with('ca1208a63669d4d4ad7452367008d40fa090f645').returns(true)
@@ -143,7 +143,7 @@ module DiscourseCodeReview
     end
 
     it "approves followed-up topics with partial hashes" do
-      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil)
+      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil, repo_id: 24)
       repo.expects(:default_branch_contains?).with('5ff6c10320cab7ef82ecda40c57cfb9e539b7e72').returns(true)
       repo.expects(:followees).with('5ff6c10320cab7ef82ecda40c57cfb9e539b7e72').returns([])
       repo.expects(:default_branch_contains?).with('dbfb2a1e11b6a4f33d35b26885193774e7ab9362').returns(true)
@@ -173,7 +173,7 @@ module DiscourseCodeReview
     end
 
     it "does not extract followees from revert commits" do
-      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil)
+      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil, repo_id: 24)
       repo.expects(:default_branch_contains?).with('154f503d2e99f904356b52f2fae9edcc495708fa').returns(true)
       repo.expects(:followees).with('154f503d2e99f904356b52f2fae9edcc495708fa').returns([])
       repo.expects(:default_branch_contains?).with('d2a7f29595786376a3010cb7e320d66f5b8d60ef').returns(true)

--- a/spec/discourse_code_review/lib/state/github_repo_categories_spec.rb
+++ b/spec/discourse_code_review/lib/state/github_repo_categories_spec.rb
@@ -47,26 +47,32 @@ describe DiscourseCodeReview::State::GithubRepoCategories do
     }.to_not change { Category.count }
   end
 
+  it "does not create a new category without repo_id" do
+    expect {
+      described_class.ensure_category(repo_name: "repo-name")
+    }.to_not change { Category.count }
+  end
+
   context "code_review_default_mute_new_categories enabled" do
     before do
       SiteSetting.code_review_default_mute_new_categories = true
     end
 
     it "can add the category" do
-      c = described_class.ensure_category(repo_name: "repo-name")
+      c = described_class.ensure_category(repo_name: "repo-name", repo_id: 24)
       expect(SiteSetting.default_categories_muted).to eq(c.id.to_s)
 
-      c2 = described_class.ensure_category(repo_name: "repo-name2")
+      c2 = described_class.ensure_category(repo_name: "repo-name2", repo_id: 25)
       expect(SiteSetting.default_categories_muted.split("|").map(&:to_i)).to contain_exactly(c.id, c2.id)
     end
 
     it "removes categories that were deleted" do
-      c = described_class.ensure_category(repo_name: "repo-name")
+      c = described_class.ensure_category(repo_name: "repo-name", repo_id: 24)
       expect(SiteSetting.default_categories_muted).to eq(c.id.to_s)
 
       c.destroy
 
-      c2 = described_class.ensure_category(repo_name: "repo-name2")
+      c2 = described_class.ensure_category(repo_name: "repo-name2", repo_id: 25)
       expect(SiteSetting.default_categories_muted.split("|").map(&:to_i)).to contain_exactly(c2.id)
     end
   end

--- a/spec/jobs/code_review_sync_commits_spec.rb
+++ b/spec/jobs/code_review_sync_commits_spec.rb
@@ -37,7 +37,7 @@ describe Jobs::CodeReviewSyncCommits, type: :code_review_integration do
 
     it "creates a commit topic and a category topic" do
       expect {
-        described_class.new.execute(repo_name: '10xninjarockstar/ultimatetodolist')
+        described_class.new.execute(repo_name: '10xninjarockstar/ultimatetodolist', repo_id: 24)
       }.to change { Topic.count }.by(2)
 
       topics = Topic.order('id desc').limit(2)


### PR DESCRIPTION
This commit prevents creation of duplicate code-review categories.