### PR TITLE
FIX: ensures we are not attempting to store a too ling title

### DIFF
--- a/lib/discourse_code_review/state/commit_topics.rb
+++ b/lib/discourse_code_review/state/commit_topics.rb
@@ -94,10 +94,16 @@ module DiscourseCodeReview::State::CommitTopics
 
             tags << SiteSetting.code_review_commit_tag
 
+            truncated_title =
+              if Topic.fancy_title(title).length > Topic.max_fancy_title_length
+                Topic.fancy_title(title).truncate(Topic.max_fancy_title_length)
+              else
+                title
+
             post = PostCreator.create!(
               user,
               raw: raw,
-              title: title,
+              title: truncated_title,
               created_at: commit[:date],
               category: category_id,
               tags: tags,


### PR DESCRIPTION
Before this fix a very long title would bypass validation (as we use skip_validations: true) and would then fail in the database insert as fancy_title is `character varying(400)`

```
ActiveRecord::ValueTooLong: PG::StringDataRightTruncation: ERROR:  value too long for type character varying(400)
```