### PR TITLE
DEV: simplify truncation logic

### DIFF
--- a/lib/discourse_code_review/state/commit_topics.rb
+++ b/lib/discourse_code_review/state/commit_topics.rb
@@ -94,17 +94,10 @@ module DiscourseCodeReview::State::CommitTopics
 
             tags << SiteSetting.code_review_commit_tag
 
-            truncated_title =
-              if Topic.fancy_title(title).length > Topic.max_fancy_title_length
-                Topic.fancy_title(title).truncate(Topic.max_fancy_title_length)
-              else
-                title
-              end
-
             post = PostCreator.create!(
               user,
               raw: raw,
-              title: truncated_title,
+              title: Topic.fancy_title(title).truncate(Topic.max_fancy_title_length),
               created_at: commit[:date],
               category: category_id,
               tags: tags,


### PR DESCRIPTION
It avoid calling `Topic.fancy_title` two times, it works because Topic.fancy_title(title) when under limit with mostly return a safe version of title