### PR TITLE
FIX: brute force title length until it works for fancy_title max length

### DIFF
--- a/lib/discourse_code_review/state/commit_topics.rb
+++ b/lib/discourse_code_review/state/commit_topics.rb
@@ -95,10 +95,15 @@ module DiscourseCodeReview::State::CommitTopics
             tags << SiteSetting.code_review_commit_tag
 
             truncated_title = title
-            truncation = 0
+            iterations = 0
             while Topic.fancy_title(truncated_title).length > Topic.max_fancy_title_length
-              truncation += 50
-              truncated_title = truncated_title.truncate(Topic.max_fancy_title_length - truncation)
+              if iterations >= 3
+                truncated_title = "Automatic title for commit #{commit[:hash][0...8]}"
+                break
+              end
+              iterations += 1
+              truncation = [10, Topic.max_fancy_title_length - iterations * 50].max
+              truncated_title = truncated_title.truncate(truncation)
             end
 
             post = PostCreator.create!(

--- a/lib/discourse_code_review/state/commit_topics.rb
+++ b/lib/discourse_code_review/state/commit_topics.rb
@@ -94,10 +94,17 @@ module DiscourseCodeReview::State::CommitTopics
 
             tags << SiteSetting.code_review_commit_tag
 
+            truncated_title = title
+            truncation = 0
+            while Topic.fancy_title(truncated_title).length > Topic.max_fancy_title_length
+              truncation += 50
+              truncated_title = truncated_title.truncate(Topic.max_fancy_title_length - truncation)
+            end
+
             post = PostCreator.create!(
               user,
               raw: raw,
-              title: Topic.fancy_title(title).truncate(Topic.max_fancy_title_length),
+              title: truncated_title,
               created_at: commit[:date],
               category: category_id,
               tags: tags,


### PR DESCRIPTION
Given the automatic nature of this post creation, we can't ask user to modify input and have to do it ourselves beforehand.