### PR TITLE
DEV: Update `rugged` and other deps

### DIFF
--- a/lib/discourse_code_review/source/git_repo.rb
+++ b/lib/discourse_code_review/source/git_repo.rb
@@ -113,8 +113,8 @@ module DiscourseCodeReview::Source
     private
 
     def rugged_commits_since(from, to)
-      from = @repo.rev_parse(from) if from
-      to = @repo.rev_parse(to)
+      from = @repo.rev_parse(from).oid if from
+      to = @repo.rev_parse(to).oid
 
       walker = Rugged::Walker.new(@repo)
       walker.push(to)

--- a/plugin.rb
+++ b/plugin.rb
@@ -9,12 +9,12 @@
 # match version in discourse dev
 gem 'addressable', '2.7.0'
 gem 'sawyer', '0.8.2'
-gem 'octokit', '4.16.0'
+gem 'octokit', '4.21.0'
 gem 'pqueue', '2.1.0'
-gem 'rugged', '0.28.4.1'
+gem 'rugged', '1.1.0'
 
 if Rails.env.test?
-  gem 'graphql', '1.11.6'
+  gem 'graphql', '1.12.12'
 end
 
 enabled_site_setting :code_review_enabled

--- a/spec/discourse_code_review/lib/github_repo_spec.rb
+++ b/spec/discourse_code_review/lib/github_repo_spec.rb
@@ -23,7 +23,7 @@ module DiscourseCodeReview
           @origin_path = origin_path
 
           `git init #{origin_path}`
-          `git branch -m main`
+          system("git checkout -q -b main", chdir: origin_path)
           DiscourseCodeReview::Source::GitRepo.new(origin_path, checkout_path)
 
           Dir.chdir(checkout_path) do

--- a/spec/discourse_code_review/lib/github_repo_spec.rb
+++ b/spec/discourse_code_review/lib/github_repo_spec.rb
@@ -39,11 +39,11 @@ module DiscourseCodeReview
           `git add a`
           `git commit -am 'first commit'`
 
-          `git checkout -b test`
+          `git checkout -q -b test`
           File.write('b', 'test')
           `git add b`
           `git commit -am testing`
-          `git checkout master`
+          `git checkout -q master`
 
           File.write('a', "hello world\n")
           `git commit -am 'second commit'`

--- a/spec/discourse_code_review/lib/github_repo_spec.rb
+++ b/spec/discourse_code_review/lib/github_repo_spec.rb
@@ -22,7 +22,7 @@ module DiscourseCodeReview
         with_tmpdir do |origin_path|
           @origin_path = origin_path
 
-          `git init #{origin_path}`
+          `git init -b main #{origin_path}`
           DiscourseCodeReview::Source::GitRepo.new(origin_path, checkout_path)
 
           Dir.chdir(checkout_path) do

--- a/spec/discourse_code_review/lib/github_repo_spec.rb
+++ b/spec/discourse_code_review/lib/github_repo_spec.rb
@@ -43,7 +43,7 @@ module DiscourseCodeReview
           File.write('b', 'test')
           `git add b`
           `git commit -am testing`
-          `git checkout -q master`
+          `git checkout -q main`
 
           File.write('a', "hello world\n")
           `git commit -am 'second commit'`
@@ -54,11 +54,11 @@ module DiscourseCodeReview
 
       it "does not explode" do
         repo = GithubRepo.new('fake_repo/fake_repo', nil, nil, repo_id: 24)
-        repo.stubs(:default_branch).returns("origin/master")
+        repo.stubs(:default_branch).returns("origin/main")
         repo.path = checkout_path
         repo.last_commit = nil
 
-        commits = repo.commits_since("origin/master~2", merge_github_info: false)
+        commits = repo.commits_since("origin/main~2", merge_github_info: false)
 
         expect(commits.last[:diff]).to eq("MERGE COMMIT")
       end
@@ -77,7 +77,7 @@ module DiscourseCodeReview
 
       it "truncates the diff" do
         repo = GithubRepo.new('fake_repo/fake_repo', nil, nil, repo_id: 24)
-        repo.stubs(:default_branch).returns("origin/master")
+        repo.stubs(:default_branch).returns("origin/main")
         repo.path = checkout_path
         repo.last_commit = nil
 
@@ -109,7 +109,7 @@ module DiscourseCodeReview
       end
 
       repo = GithubRepo.new('fake_repo/fake_repo', nil, nil, repo_id: 24)
-      repo.stubs(:default_branch).returns("origin/master")
+      repo.stubs(:default_branch).returns("origin/main")
       repo.path = checkout_path
 
       SiteSetting.code_review_catch_up_commits = 1
@@ -131,7 +131,7 @@ module DiscourseCodeReview
       end
 
       repo = GithubRepo.new('fake_repo/fake_repo', nil, nil, repo_id: 24)
-      repo.stubs(:default_branch).returns("origin/master")
+      repo.stubs(:default_branch).returns("origin/main")
       repo.path = checkout_path
 
       # mimic force push event

--- a/spec/discourse_code_review/lib/github_repo_spec.rb
+++ b/spec/discourse_code_review/lib/github_repo_spec.rb
@@ -22,7 +22,8 @@ module DiscourseCodeReview
         with_tmpdir do |origin_path|
           @origin_path = origin_path
 
-          `git init -b main #{origin_path}`
+          `git init #{origin_path}`
+          `git branch -m main`
           DiscourseCodeReview::Source::GitRepo.new(origin_path, checkout_path)
 
           Dir.chdir(checkout_path) do

--- a/spec/helpers/integration.rb
+++ b/spec/helpers/integration.rb
@@ -6,7 +6,7 @@ require_relative 'rugged_interceptor'
 require_relative 'github_rest_api_mock'
 
 module CodeReviewIntegrationHelpers
-  def declare_github_repo!(owner:, repo:, default_branch: "master", &blk)
+  def declare_github_repo!(owner:, repo:, default_branch: "main", &blk)
     local = RemoteMocks.make_repo
 
     RuggedInterceptor::Repository.intercept(

--- a/spec/lib/tasks/code_review_sha_backfill_spec.rb
+++ b/spec/lib/tasks/code_review_sha_backfill_spec.rb
@@ -40,18 +40,24 @@ some code
 
     it "updates the post raw with the post revisor to have the full sha" do
       original_raw = post.raw
-      Rake::Task['code_review_full_sha_backfill'].invoke
+      capture_stdout do
+        Rake::Task['code_review_full_sha_backfill'].invoke
+      end
       post.reload
 
       expect(post.raw.chomp).to eq(original_raw.gsub("sha: c187ede3", "sha: c187ede3c67f23478bc2d3c20187bd98ac025b9e").chomp)
     end
 
     it "is idempotent based on raw not changing and the query not getting longer shas" do
-      Rake::Task['code_review_full_sha_backfill'].invoke
+      capture_stdout do
+        Rake::Task['code_review_full_sha_backfill'].invoke
+      end
       post_baked_at = post.reload.baked_at
       Rake::Task['code_review_full_sha_backfill'].reenable
 
-      Rake::Task['code_review_full_sha_backfill'].invoke
+      capture_stdout do
+        Rake::Task['code_review_full_sha_backfill'].invoke
+      end
       expect(post.reload.baked_at).to eq_time(post_baked_at)
     end
   end


### PR DESCRIPTION
Updates `rugged` (and fixes a breaking change introduced in ~1.1), `octokit`, and `graphql`.
Also changes `master` branch to `main` in specs, and captures output in specs.