### PR TITLE
FIX: Translations for bad_github_X were missing

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -26,3 +26,5 @@ en:
   discourse_code_review:
     category_description: |
       This category was created to contain code reviews for %{repo_name}. Topics are created for each commit or pull request.
+    bad_github_permissions_error: "There was an issue when fetching webhook data from GitHub. Please check your token configured in the code_review_github_token site setting has the 'repo' scope enabled. See https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps for more details."
+    bad_github_credentials_error: "There was an issue with your GitHub credentials. Please check your code_review_github_token site setting and try again."


### PR DESCRIPTION
For some reason I did not include these in the original
commit at
https://github.com/discourse/discourse-code-review/commit/40423c19f45fd22240c530b958913d4e95a5f7ad.