### PR TITLE
FIX: Allow dots in repo names

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -231,7 +231,7 @@ after_initialize do
 
           # need to allow dots in the id, use the same username
           # regex from core
-          resources :repos, only: [:index], id: /[%\w.\-]+?/ do
+          resources :repos, only: [:index], id: /[\w.\-]+?/ do
             member do
               get '/has-configured-webhook' => 'repos#has_configured_webhook'
               post '/configure-webhook' => 'repos#configure_webhook'

--- a/plugin.rb
+++ b/plugin.rb
@@ -228,7 +228,10 @@ after_initialize do
 
       scope format: true, constraints: { format: 'json' } do
         resources :organizations, only: [:index] do
-          resources :repos, only: [:index] do
+
+          # need to allow dots in the id, use the same username
+          # regex from core
+          resources :repos, only: [:index], id: /[%\w.\-]+?/ do
             member do
               get '/has-configured-webhook' => 'repos#has_configured_webhook'
               post '/configure-webhook' => 'repos#configure_webhook'

--- a/spec/requests/discourse_code_review/repos_controller_spec.rb
+++ b/spec/requests/discourse_code_review/repos_controller_spec.rb
@@ -135,7 +135,7 @@ describe DiscourseCodeReview::ReposController do
 
           it "does not 404 error" do
             get "/admin/plugins/code-review/organizations/org/repos/#{repo_name}/has-configured-webhook.json"
-            expect(response.status).not_to eq(404)
+            expect(response.status).to eq(200)
             expect(JSON.parse(response.body)).to eq('has_configured_webhook' => true)
           end
         end

--- a/spec/requests/discourse_code_review/repos_controller_spec.rb
+++ b/spec/requests/discourse_code_review/repos_controller_spec.rb
@@ -133,7 +133,7 @@ describe DiscourseCodeReview::ReposController do
         context "when repo name has a . in it" do
           let(:repo_name) { "Some-coolrepo.org" }
 
-          it "does not 404 error" do
+          it "returns the right response" do
             get "/admin/plugins/code-review/organizations/org/repos/#{repo_name}/has-configured-webhook.json"
             expect(response.status).to eq(200)
             expect(JSON.parse(response.body)).to eq('has_configured_webhook' => true)

--- a/spec/requests/discourse_code_review/repos_controller_spec.rb
+++ b/spec/requests/discourse_code_review/repos_controller_spec.rb
@@ -105,9 +105,10 @@ describe DiscourseCodeReview::ReposController do
       end
 
       context "when a webhook is configured" do
+        let(:repo_name) { "repo" }
         let!(:client) do
           client = mock
-          client.stubs(:hooks).with('org/repo').returns([
+          client.stubs(:hooks).with("org/#{repo_name}").returns([
             {
               events: webhook_events,
               config: {
@@ -125,8 +126,18 @@ describe DiscourseCodeReview::ReposController do
         end
 
         it "says yes" do
-          get '/admin/plugins/code-review/organizations/org/repos/repo/has-configured-webhook.json'
+          get "/admin/plugins/code-review/organizations/org/repos/#{repo_name}/has-configured-webhook.json"
           expect(JSON.parse(response.body)).to eq('has_configured_webhook' => true)
+        end
+
+        context "when repo name has a . in it" do
+          let(:repo_name) { "Some-coolrepo.org" }
+
+          it "does not 404 error" do
+            get "/admin/plugins/code-review/organizations/org/repos/#{repo_name}/has-configured-webhook.json"
+            expect(response.status).not_to eq(404)
+            expect(JSON.parse(response.body)).to eq('has_configured_webhook' => true)
+          end
         end
       end
 


### PR DESCRIPTION
Rails does not allow dots in route params by default.
This can be allowed using a route constraint. I used the
same one we use for usernames in core. Without this,
a 404 error is raised on has_webhooks for any repo with
a . in the name.