### PR TITLE
DEV: Remove `addressable` dependency

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -6,8 +6,6 @@
 # authors: Sam Saffron
 # url: https://github.com/discourse/discourse-code-review
 
-# match version in discourse dev
-gem 'addressable', '2.7.0'
 gem 'sawyer', '0.8.2'
 gem 'octokit', '4.21.0'
 gem 'pqueue', '2.1.0'


### PR DESCRIPTION
It's now included by default in core. Having it declared here makes updating it difficult. See: https://github.com/discourse/discourse/pull/13625