### PR TITLE
FIX: Do not parse emoji in commit message

### DIFF
--- a/lib/discourse_code_review/state/commit_topics.rb
+++ b/lib/discourse_code_review/state/commit_topics.rb
@@ -5,7 +5,7 @@ module DiscourseCodeReview::State::CommitTopics
     def auto_link_commits(text, doc = nil)
       linked_commits = find_linked_commits(text)
       if (linked_commits.length > 0)
-        doc ||= Nokogiri::HTML5::fragment(PrettyText.cook(text))
+        doc ||= Nokogiri::HTML5::fragment(PrettyText.cook(text, disable_emojis: true))
         skip_tags = ["a", "code"]
         linked_commits.each do |hash, topic|
           doc.traverse do |node|


### PR DESCRIPTION
The commit message is converted to HTML and back to Markdown to link
other commits. When this happened, Emojis were converted to img HTML
tags and then to image Markdown. This commit disables emojis parser to
make sure no images are inserted in commit message.