### PR TITLE
FIX: Don't duplicate notifications if receiving duplicate webhooks.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -328,6 +328,8 @@ after_initialize do
         previous_approved_count = previous_approved_count.map(&:to_i).sum
         data.merge(num_approved_commits: previous_approved_count + 1)
       end
+    ).set_precondition(
+      precondition_blk: Proc.new { |data| data[:num_approved_commits] > 1 }
     )
 
     register_notification_consolidation_plan(consolidation_plan)


### PR DESCRIPTION
Since we changed how the approved commit notification consolidation works, we no longer delete previous notifications after creating a consolidated one. This revealed a race condition where we create duplicated notifications, consolidating it into itself:

<img width="575" alt="Screen Shot 2021-12-27 at 12 32 54" src="https://user-images.githubusercontent.com/5025816/147486045-24fa4bd1-a7e7-4355-98cc-54b1f15d674a.png">


To fix this, this commit makes the approved tag check atomic using a mutex.