### PR TITLE
DEV: Prefer tables over custom fields, github categories, step 1

### DIFF
--- a/app/models/github_repo_category.rb
+++ b/app/models/github_repo_category.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class DiscourseCodeReview::GithubRepoCategory < ActiveRecord::Base
+  self.table_name = 'code_review_github_repos'
+  belongs_to :category
+end

--- a/db/migrate/20220111185133_create_code_review_github_repos.rb
+++ b/db/migrate/20220111185133_create_code_review_github_repos.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class CreateCodeReviewGithubRepos < ActiveRecord::Migration[6.1]
+  def change
+    create_table :code_review_github_repos, id: false do |t|
+      t.integer :category_id, null: false, primary_key: true
+      t.text :name
+      t.text :repo_id
+      t.timestamps
+    end
+
+    add_index :code_review_github_repos, :repo_id, unique: true
+    add_index :code_review_github_repos, :name, unique: true
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          INSERT INTO code_review_github_repos (category_id, repo_id, name, created_at, updated_at)
+          SELECT
+            categories.id,
+            repo_ids.value,
+            names.value,
+            least(repo_ids.created_at, names.created_at),
+            greatest(repo_ids.updated_at, names.updated_at)
+          FROM categories
+          LEFT OUTER JOIN
+            (
+              SELECT *
+              FROM category_custom_fields
+              WHERE name = 'GitHub Repo Name'
+            ) names
+          ON names.category_id = categories.id
+          LEFT OUTER JOIN
+            (
+              SELECT *
+              FROM category_custom_fields
+              WHERE name = 'GitHub Repo ID'
+            ) repo_ids
+          ON repo_ids.category_id = categories.id
+          WHERE repo_ids.value IS NOT NULL
+          OR names.value IS NOT NULL
+        SQL
+      end
+    end
+  end
+end

--- a/lib/discourse_code_review/github_pr_syncer.rb
+++ b/lib/discourse_code_review/github_pr_syncer.rb
@@ -66,8 +66,8 @@ module DiscourseCodeReview
 
     def sync_all
       State::GithubRepoCategories
-        .github_repo_category_fields.each do |field|
-          sync_repo(field.value)
+        .each_repo_name do |name|
+          sync_repo(name)
         end
     end
 

--- a/lib/discourse_code_review/state/github_repo_categories.rb
+++ b/lib/discourse_code_review/state/github_repo_categories.rb
@@ -1,42 +1,27 @@
 # frozen_string_literal: true
 
-module DiscourseCodeReview::State::GithubRepoCategories
-  GITHUB_REPO_ID = "GitHub Repo ID"
-  GITHUB_REPO_NAME = "GitHub Repo Name"
+module DiscourseCodeReview
+  module State::GithubRepoCategories
+    GITHUB_REPO_ID = "GitHub Repo ID"
+    GITHUB_REPO_NAME = "GitHub Repo Name"
 
-  class << self
-    def ensure_category(repo_name:, repo_id: nil)
-      Category.transaction(requires_new: true) do
-        category =
-          Category.where(
-            id:
-              CategoryCustomField
-                .select(:category_id)
-                .where(name: GITHUB_REPO_NAME, value: repo_name)
-          ).first
+    class << self
+      def ensure_category(repo_name:, repo_id: nil)
+        ActiveRecord::Base.transaction(requires_new: true) do
+          repo_category =
+            GithubRepoCategory
+              .find_by(repo_id: repo_id)
 
-        if category.present? && category.custom_fields[GITHUB_REPO_ID].blank? && repo_id.present?
-          category.custom_fields[GITHUB_REPO_ID] = repo_id
-          category.save_custom_fields
-        end
+          repo_category ||=
+            GithubRepoCategory
+              .find_by(name: repo_name)
 
-        # search for category via repo_id
-        if category.blank? && repo_id.present?
-          category =
-            Category.where(
-              id:
-                CategoryCustomField
-                  .select(:category_id)
-                .where(name: GITHUB_REPO_ID, value: repo_id)
-            ).first
+          category = repo_category&.category
 
-          if category.present?
-            # update repository name in category custom field
-            category.custom_fields[GITHUB_REPO_NAME] = repo_name
-            category.save_custom_fields
-          else
+          if !category && repo_id.present?
             # create new category
             short_name = find_category_name(repo_name.split("/", 2).last)
+
             category = Category.new(
               name: short_name,
               user: Discourse.system_user,
@@ -54,40 +39,44 @@ module DiscourseCodeReview::State::GithubRepoCategories
               SiteSetting.default_categories_muted = (existing_category_ids << category.id).join("|")
             end
 
+            repo_category = GithubRepoCategory.new(category_id: category.id)
+          end
+
+          if category
+            repo_category.repo_id = repo_id
+            repo_category.name = repo_name
+            repo_category.save! if repo_category.changed?
+
             category.custom_fields[GITHUB_REPO_ID] = repo_id
             category.custom_fields[GITHUB_REPO_NAME] = repo_name
             category.save_custom_fields
           end
+
+          category
         end
-
-        category
       end
-    end
 
-    def each_repo_name(&blk)
-      CategoryCustomField
-        .where(name: GITHUB_REPO_NAME)
-        .pluck(:value)
-        .each(&blk)
-    end
+      def each_repo_name(&blk)
+        GithubRepoCategory
+          .pluck(:name)
+          .each(&blk)
+      end
 
-    def github_repo_category_fields
-      CategoryCustomField
-        .where(name: GITHUB_REPO_NAME)
-        .include(:category)
-    end
+      def get_repo_name_from_topic(topic)
+        GithubRepoCategory
+          .where(category_id: topic.category_id)
+          .first
+          &.name
+      end
 
-    def get_repo_name_from_topic(topic)
-      topic.category.custom_fields[GITHUB_REPO_NAME]
-    end
+      private
 
-    private
-
-    def find_category_name(name)
-      if Category.where(name: name).exists?
-        name += SecureRandom.hex
-      else
-        name
+      def find_category_name(name)
+        if Category.where(name: name).exists?
+          name += SecureRandom.hex
+        else
+          name
+        end
       end
     end
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -188,6 +188,7 @@ after_initialize do
   require File.expand_path("../app/controllers/discourse_code_review/repos_controller.rb", __FILE__)
   require File.expand_path("../app/controllers/discourse_code_review/admin_code_review_controller.rb", __FILE__)
   require File.expand_path("../app/models/skipped_code_review.rb", __FILE__)
+  require File.expand_path("../app/models/github_repo_category.rb", __FILE__)
   require File.expand_path("../app/jobs/regular/code_review_sync_commits", __FILE__)
   require File.expand_path("../app/jobs/regular/code_review_sync_commit_comments", __FILE__)
   require File.expand_path("../lib/enumerators", __FILE__)

--- a/spec/discourse_code_review/lib/state/github_repo_categories_spec.rb
+++ b/spec/discourse_code_review/lib/state/github_repo_categories_spec.rb
@@ -14,6 +14,7 @@ describe DiscourseCodeReview::State::GithubRepoCategories do
 
   it "can use an existing category" do
     c = Fabricate(:category, name: "repo-name")
+    DiscourseCodeReview::GithubRepoCategory.create!(category_id: c.id, name: 'repo-name')
     c.custom_fields[DiscourseCodeReview::State::GithubRepoCategories::GITHUB_REPO_NAME] = "repo-name"
     c.save_custom_fields
     expect {
@@ -26,11 +27,12 @@ describe DiscourseCodeReview::State::GithubRepoCategories do
 
   it "can use an existing category based on repository ID" do
     c = Fabricate(:category, name: "repo-name")
+    DiscourseCodeReview::GithubRepoCategory.create!(category_id: c.id, name: 'repo-name', repo_id: '242')
     c.custom_fields[DiscourseCodeReview::State::GithubRepoCategories::GITHUB_REPO_ID] = "242"
     c.custom_fields[DiscourseCodeReview::State::GithubRepoCategories::GITHUB_REPO_NAME] = "repo-name"
     c.save_custom_fields
     expect {
-      c = described_class.ensure_category(repo_name: "new-repo-name", repo_id: 242)
+      c = described_class.ensure_category(repo_name: "new-repo-name", repo_id: "242")
       expect(c.name).to eq("repo-name")
     }.to_not change { Category.count }
     # updates repository name in custom field
@@ -40,6 +42,7 @@ describe DiscourseCodeReview::State::GithubRepoCategories do
   it "does not break when repository ID is not present" do
     c = Fabricate(:category, name: "repo-name")
     c.custom_fields[DiscourseCodeReview::State::GithubRepoCategories::GITHUB_REPO_NAME] = "repo-name"
+    DiscourseCodeReview::GithubRepoCategory.create!(category_id: c.id, name: 'repo-name')
     c.save_custom_fields
     expect {
       c = described_class.ensure_category(repo_name: "repo-name")


### PR DESCRIPTION
This version still writes the data to custom fields for easier
reversion, just in case.