### PR TITLE
DEV: Prefer tables over custom fields, commit topics, part 1

### DIFF
--- a/app/controllers/discourse_code_review/code_review_controller.rb
+++ b/app/controllers/discourse_code_review/code_review_controller.rb
@@ -153,18 +153,18 @@ module DiscourseCodeReview
       sha1 = params[:sha1]
 
       if sha1.present? && sha1.size >= 7
-        tcf = TopicCustomField
-          .where(name: DiscourseCodeReview::COMMIT_HASH)
-          .where("LEFT(LOWER(value), :len) = LOWER(:sha1)", len: sha1.size, sha1: sha1)
-          .order("created_at DESC")
-          .includes(:topic)
-          .first
+        topic =
+          Topic
+            .joins(:code_review_commit_topic)
+            .where("LEFT(LOWER(code_review_commit_topics.sha), :len) = LOWER(:sha1)", len: sha1.size, sha1: sha1)
+            .order("created_at DESC")
+            .first
       end
 
-      raise Discourse::NotFound.new if tcf.blank?
-      guardian.ensure_can_see!(tcf.topic)
+      raise Discourse::NotFound.new unless topic
+      guardian.ensure_can_see!(topic)
 
-      redirect_to tcf.topic.url
+      redirect_to topic.url
     end
 
     protected

--- a/app/models/commit_topic.rb
+++ b/app/models/commit_topic.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class DiscourseCodeReview::CommitTopic < ActiveRecord::Base
+  self.table_name = 'code_review_commit_topics'
+  belongs_to :topic
+end

--- a/db/migrate/20220111185242_create_code_review_commit_topics.rb
+++ b/db/migrate/20220111185242_create_code_review_commit_topics.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class CreateCodeReviewCommitTopics < ActiveRecord::Migration[6.1]
+  def change
+    create_table :code_review_commit_topics, id: false do |t|
+      t.integer :topic_id, null: false, primary_key: true
+      t.text :sha, null: false
+      t.timestamps
+    end
+
+    add_index :code_review_commit_topics, :sha, unique: true
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          INSERT INTO code_review_commit_topics (topic_id, sha, created_at, updated_at)
+          SELECT
+            topics.id,
+            github_hashes.value,
+            github_hashes.created_at,
+            github_hashes.updated_at
+          FROM
+            (
+              SELECT *
+              FROM topic_custom_fields
+              WHERE name = 'commit hash'
+            ) github_hashes
+          INNER JOIN topics
+          ON github_hashes.topic_id = topics.id
+        SQL
+      end
+    end
+  end
+end

--- a/lib/discourse_code_review/github_pr_syncer.rb
+++ b/lib/discourse_code_review/github_pr_syncer.rb
@@ -80,16 +80,8 @@ module DiscourseCodeReview
     def apply_github_approves(repo_name, commit_hash)
       topic =
         Topic
-          .where(
-            id:
-              TopicCustomField
-                .where(
-                  name: COMMIT_HASH,
-                  value: commit_hash
-                )
-                .limit(1)
-                .select(:topic_id)
-          )
+          .joins(:code_review_commit_topic)
+          .where(code_review_commit_topics: { sha: commit_hash })
           .first
 
       if topic

--- a/lib/discourse_code_review/rake_tasks.rb
+++ b/lib/discourse_code_review/rake_tasks.rb
@@ -9,15 +9,7 @@ module DiscourseCodeReview
       end
 
       Rake::Task.define_task code_review_tag_commits: :environment do
-        topics =
-          Topic
-            .where(
-            id:
-            TopicCustomField
-          .select(:topic_id)
-          .where(name: DiscourseCodeReview::COMMIT_HASH)
-          )
-            .to_a
+        topics = Topic.joins(:code_review_commit_topic).to_a
 
           puts "Tagging #{topics.size} topics"
 
@@ -34,9 +26,9 @@ module DiscourseCodeReview
       Rake::Task.define_task code_review_full_sha_backfill: :environment do
         posts_with_commit = Post
           .joins("INNER JOIN topics ON topics.id = posts.topic_id")
-          .joins("INNER JOIN topic_custom_fields ON topics.id = topic_custom_fields.topic_id")
-          .includes(topic: :_custom_fields)
-          .where("topic_custom_fields.name = '#{DiscourseCodeReview::COMMIT_HASH}' AND
+          .joins("INNER JOIN code_review_commit_topics ON topics.id = code_review_commit_topics.topic_id")
+          .includes(topic: :code_review_commit_topic)
+          .where("
             topics.deleted_at IS NULL AND
             posts.deleted_at IS NULL AND
             posts.post_number = 1 AND
@@ -51,7 +43,7 @@ module DiscourseCodeReview
         posts_with_commit.find_each do |post_with_commit|
           puts "Replacing sha in post #{post_with_commit.id}..."
 
-          full_git_sha = post_with_commit.topic.custom_fields[DiscourseCodeReview::COMMIT_HASH]
+          full_git_sha = post_with_commit.topic.code_review_commit_topic.sha
           new_raw = post_with_commit.raw.gsub(/sha: [0-9a-f]{6,10}\b/, "sha: #{full_git_sha}")
 
           if new_raw == post_with_commit.raw

--- a/lib/discourse_code_review/state/commit_topics.rb
+++ b/lib/discourse_code_review/state/commit_topics.rb
@@ -1,208 +1,214 @@
 # frozen_string_literal: true
 
-module DiscourseCodeReview::State::CommitTopics
-  class << self
-    def auto_link_commits(text, doc = nil)
-      linked_commits = find_linked_commits(text)
-      if (linked_commits.length > 0)
-        doc ||= Nokogiri::HTML5::fragment(PrettyText.cook(text, disable_emojis: true))
-        skip_tags = ["a", "code"]
-        linked_commits.each do |hash, topic|
-          doc.traverse do |node|
-            if node.text? && !skip_tags.include?(node.parent&.name)
-              node.replace node.content.gsub(hash, "<a href='#{topic.url}'>#{hash}</a>")
+module DiscourseCodeReview
+  module State::CommitTopics
+    class << self
+      def auto_link_commits(text, doc = nil)
+        linked_commits = find_linked_commits(text)
+        if (linked_commits.length > 0)
+          doc ||= Nokogiri::HTML5::fragment(PrettyText.cook(text, disable_emojis: true))
+          skip_tags = ["a", "code"]
+          linked_commits.each do |hash, topic|
+            doc.traverse do |node|
+              if node.text? && !skip_tags.include?(node.parent&.name)
+                node.replace node.content.gsub(hash, "<a href='#{topic.url}'>#{hash}</a>")
+              end
             end
+            text = HtmlToMarkdown.new(doc.to_html).to_markdown
           end
-          text = HtmlToMarkdown.new(doc.to_html).to_markdown
         end
-      end
-      [text, linked_commits, doc]
-    end
-
-    def detect_shas(text)
-      text.scan(/(?:[^a-zA-Z0-9]|^)([a-f0-9]{8,})(?:[^a-zA-Z0-9]|$)/).flatten
-    end
-
-    def ensure_commit_comment(user:, topic_id:, comment:)
-      context = ""
-      if comment[:line_content]
-        context = <<~MD
-          [quote]
-          #{comment[:path]}
-
-          ```diff
-          #{comment[:line_content]}
-          ```
-
-          [/quote]
-
-        MD
+        [text, linked_commits, doc]
       end
 
-      custom_fields = {}
-      custom_fields[DiscourseCodeReview::COMMENT_PATH] = comment[:path] if comment[:path].present?
-      custom_fields[DiscourseCodeReview::COMMENT_POSITION] = comment[:position] if comment[:position].present?
+      def detect_shas(text)
+        text.scan(/(?:[^a-zA-Z0-9]|^)([a-f0-9]{8,})(?:[^a-zA-Z0-9]|$)/).flatten
+      end
 
-      DiscourseCodeReview::State::Helpers.ensure_post_with_nonce(
-        created_at: comment[:created_at],
-        custom_fields: custom_fields,
-        nonce_name: DiscourseCodeReview::GITHUB_ID,
-        nonce_value: comment[:id],
-        raw: context + comment[:body],
-        skip_validations: true,
-        topic_id: topic_id,
-        user: user,
-      )
-    end
+      def ensure_commit_comment(user:, topic_id:, comment:)
+        context = ""
+        if comment[:line_content]
+          context = <<~MD
+            [quote]
+            #{comment[:path]}
 
-    def ensure_commit(commit:, merged:, repo_name:, user:, category_id:, followees:)
-      DistributedMutex.synchronize('code-review:create-commit-topic') do
-        ActiveRecord::Base.transaction(requires_new: true) do
-          link = <<~LINK
-            [GitHub](https://github.com/#{repo_name}/commit/#{commit[:hash]})
-          LINK
+            ```diff
+            #{comment[:line_content]}
+            ```
 
-          title = commit[:subject]
-          # we add a unicode zero width joiner so code block is not corrupted
-          diff = commit[:diff].gsub('```', "`\u200d``")
+            [/quote]
 
-          truncated_message =
-            if commit[:diff_truncated]
-              "\n[... diff too long, it was truncated ...]\n"
-            end
-
-          body, linked_topics = auto_link_commits(commit[:body])
-          linked_topics.merge! find_linked_commits(title)
-
-          hash_html = "<small>sha: #{commit[:hash]}</small>"
-
-          raw = "[excerpt]\n#{body}\n[/excerpt]\n\n```diff\n#{diff}\n#{truncated_message}```\n#{link} #{hash_html}"
-
-          topic = find_topic_by_commit_hash(commit[:hash])
-
-          if topic.present?
-            if merged
-              set_merged(topic)
-            end
-          else
-            tags =
-              if merged
-                [SiteSetting.code_review_pending_tag]
-              else
-                [SiteSetting.code_review_unmerged_tag]
-              end
-
-            tags << SiteSetting.code_review_commit_tag
-
-            truncated_title = title
-            iterations = 0
-            while Topic.fancy_title(truncated_title).length > Topic.max_fancy_title_length
-              if iterations >= 3
-                truncated_title = "Automatic title for commit #{commit[:hash][0...8]}"
-                break
-              end
-              iterations += 1
-              truncation = [10, Topic.max_fancy_title_length - iterations * 50].max
-              truncated_title = truncated_title.truncate(truncation)
-            end
-
-            post = PostCreator.create!(
-              user,
-              raw: raw,
-              title: truncated_title,
-              created_at: commit[:date],
-              category: category_id,
-              tags: tags,
-              skip_validations: true,
-            )
-
-            TopicCustomField.create!(
-              topic_id: post.topic_id,
-              name: DiscourseCodeReview::COMMIT_HASH,
-              value: commit[:hash]
-            )
-
-            if followees.present? && SiteSetting.code_review_auto_approve_followed_up_commits
-              followee_topics =
-                Topic
-                  .where(
-                    id:
-                      TopicCustomField
-                        .where(name: DiscourseCodeReview::COMMIT_HASH)
-                        .where('value SIMILAR TO ?', "(#{followees.join('|')})%")
-                        .select(:topic_id)
-                  )
-
-              followee_topics.each do |followee_topic|
-                DiscourseCodeReview::State::CommitApproval.followed_up(
-                  followee_topic,
-                  post.topic,
-                )
-              end
-            end
-
-            topic = post.topic
-          end
-
-          topic.id
+          MD
         end
-      end
-    end
 
-    private
+        custom_fields = {}
+        custom_fields[DiscourseCodeReview::COMMENT_PATH] = comment[:path] if comment[:path].present?
+        custom_fields[DiscourseCodeReview::COMMENT_POSITION] = comment[:position] if comment[:position].present?
 
-    def find_topic_by_commit_hash(hash)
-      DiscourseCodeReview::State::Helpers.find_topic_with_custom_field(
-        name: DiscourseCodeReview::COMMIT_HASH,
-        value: hash,
-      )
-    end
-
-    def set_merged(topic)
-      tags = topic.tags.pluck(:name)
-
-      merged_tags = [
-        SiteSetting.code_review_pending_tag,
-        SiteSetting.code_review_approved_tag,
-        SiteSetting.code_review_followup_tag
-      ]
-
-      if (tags & merged_tags).empty?
-        tags << SiteSetting.code_review_pending_tag
-        tags -= [SiteSetting.code_review_unmerged_tag]
-
-        DiscourseTagging.tag_topic_by_names(
-          topic,
-          Discourse.system_user.guardian,
-          tags
+        DiscourseCodeReview::State::Helpers.ensure_post_with_nonce(
+          created_at: comment[:created_at],
+          custom_fields: custom_fields,
+          nonce_name: DiscourseCodeReview::GITHUB_ID,
+          nonce_value: comment[:id],
+          raw: context + comment[:body],
+          skip_validations: true,
+          topic_id: topic_id,
+          user: user,
         )
       end
-    end
 
-    def find_linked_commits(text)
-      result = {}
+      def ensure_commit(commit:, merged:, repo_name:, user:, category_id:, followees:)
+        DistributedMutex.synchronize('code-review:create-commit-topic') do
+          ActiveRecord::Base.transaction(requires_new: true) do
+            link = <<~LINK
+              [GitHub](https://github.com/#{repo_name}/commit/#{commit[:hash]})
+            LINK
 
-      shas = detect_shas(text)
-      if shas.length > 0
+            title = commit[:subject]
+            # we add a unicode zero width joiner so code block is not corrupted
+            diff = commit[:diff].gsub('```', "`\u200d``")
 
-        like_clause = shas.map { |sha| "f.value LIKE '#{sha}%'" }.join(' OR ')
+            truncated_message =
+              if commit[:diff_truncated]
+                "\n[... diff too long, it was truncated ...]\n"
+              end
 
-        topics = Topic.select("topics.*, value AS sha")
-          .joins("JOIN topic_custom_fields f ON topics.id = topic_id AND f.name = '#{DiscourseCodeReview::COMMIT_HASH}'")
-          .where(like_clause)
+            body, linked_topics = auto_link_commits(commit[:body])
+            linked_topics.merge! find_linked_commits(title)
 
-        topics.each do |topic|
+            hash_html = "<small>sha: #{commit[:hash]}</small>"
 
-          lookup_shas = shas.select { |sha| topic.sha.start_with? sha }
+            raw = "[excerpt]\n#{body}\n[/excerpt]\n\n```diff\n#{diff}\n#{truncated_message}```\n#{link} #{hash_html}"
 
-          lookup_shas.each do |sha|
-            result[sha] = topic
+            topic = find_topic_by_commit_hash(commit[:hash])
+
+            if topic.present?
+              if merged
+                set_merged(topic)
+              end
+            else
+              tags =
+                if merged
+                  [SiteSetting.code_review_pending_tag]
+                else
+                  [SiteSetting.code_review_unmerged_tag]
+                end
+
+              tags << SiteSetting.code_review_commit_tag
+
+              truncated_title = title
+              iterations = 0
+              while Topic.fancy_title(truncated_title).length > Topic.max_fancy_title_length
+                if iterations >= 3
+                  truncated_title = "Automatic title for commit #{commit[:hash][0...8]}"
+                  break
+                end
+                iterations += 1
+                truncation = [10, Topic.max_fancy_title_length - iterations * 50].max
+                truncated_title = truncated_title.truncate(truncation)
+              end
+
+              post = PostCreator.create!(
+                user,
+                raw: raw,
+                title: truncated_title,
+                created_at: commit[:date],
+                category: category_id,
+                tags: tags,
+                skip_validations: true,
+              )
+
+              TopicCustomField.create!(
+                topic_id: post.topic_id,
+                name: DiscourseCodeReview::COMMIT_HASH,
+                value: commit[:hash]
+              )
+
+              CommitTopic.create!(
+                topic_id: post.topic_id,
+                sha: commit[:hash],
+              )
+
+              if followees.present? && SiteSetting.code_review_auto_approve_followed_up_commits
+                followee_topics =
+                  Topic
+                    .joins(:code_review_commit_topic)
+                    .where(
+                      'code_review_commit_topics.sha SIMILAR TO ?',
+                      "(#{followees.join('|')})%",
+                    )
+
+                followee_topics.each do |followee_topic|
+                  DiscourseCodeReview::State::CommitApproval.followed_up(
+                    followee_topic,
+                    post.topic,
+                  )
+                end
+              end
+
+              topic = post.topic
+            end
+
+            topic.id
           end
-
         end
       end
 
-      result
+      private
+
+      def find_topic_by_commit_hash(hash)
+        Topic
+          .joins(:code_review_commit_topic)
+          .where(code_review_commit_topics: { sha: hash })
+          .first
+      end
+
+      def set_merged(topic)
+        tags = topic.tags.pluck(:name)
+
+        merged_tags = [
+          SiteSetting.code_review_pending_tag,
+          SiteSetting.code_review_approved_tag,
+          SiteSetting.code_review_followup_tag
+        ]
+
+        if (tags & merged_tags).empty?
+          tags << SiteSetting.code_review_pending_tag
+          tags -= [SiteSetting.code_review_unmerged_tag]
+
+          DiscourseTagging.tag_topic_by_names(
+            topic,
+            Discourse.system_user.guardian,
+            tags
+          )
+        end
+      end
+
+      def find_linked_commits(text)
+        result = {}
+
+        shas = detect_shas(text)
+        if shas.length > 0
+
+          like_clause = shas.map { |sha| "f.sha LIKE '#{sha}%'" }.join(' OR ')
+
+          topics =
+            Topic.select("topics.*, sha")
+              .joins("JOIN code_review_commit_topics f ON topics.id = topic_id")
+              .where(like_clause)
+
+          topics.each do |topic|
+
+            lookup_shas = shas.select { |sha| topic.sha.start_with? sha }
+
+            lookup_shas.each do |sha|
+              result[sha] = topic
+            end
+
+          end
+        end
+
+        result
+      end
     end
   end
 end

--- a/spec/discourse_code_review/lib/state/commit_topics_spec.rb
+++ b/spec/discourse_code_review/lib/state/commit_topics_spec.rb
@@ -29,9 +29,11 @@ module DiscourseCodeReview
       topic = Fabricate(:topic)
       topic.custom_fields[DiscourseCodeReview::COMMIT_HASH] = "dbbadb5c357bc23daf1fa732f8670e55dc28b7cb"
       topic.save
+      CommitTopic.create!(topic_id: topic.id, sha: "dbbadb5c357bc23daf1fa732f8670e55dc28b7cb")
       topic2 = Fabricate(:topic)
       topic2.custom_fields[DiscourseCodeReview::COMMIT_HASH] = "a1db15feadc7951d8a2b4ae63384babd6c568ae0"
       topic2.save
+      CommitTopic.create!(topic_id: topic2.id, sha: "a1db15feadc7951d8a2b4ae63384babd6c568ae0")
 
       result = State::CommitTopics.auto_link_commits("a1db15feadc and another one dbbadb5c357")
       markdown = "[a1db15feadc](#{topic2.url}) and another one [dbbadb5c357](#{topic.url})"

--- a/spec/lib/tasks/code_review_sha_backfill_spec.rb
+++ b/spec/lib/tasks/code_review_sha_backfill_spec.rb
@@ -34,6 +34,7 @@ some code
     before do
       topic.custom_fields[DiscourseCodeReview::COMMIT_HASH] = 'c187ede3c67f23478bc2d3c20187bd98ac025b9e'
       topic.save_custom_fields
+      DiscourseCodeReview::CommitTopic.create!(topic_id: topic.id, sha: 'c187ede3c67f23478bc2d3c20187bd98ac025b9e')
       post.rebake!
       Rake::Task['code_review_full_sha_backfill'].reenable
     end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -37,6 +37,7 @@ describe DiscourseCodeReview do
         Fabricate(:topic, category: category).tap do |topic|
           topic.custom_fields[DiscourseCodeReview::COMMIT_HASH] = 'a commit sha'
           topic.save_custom_fields
+          DiscourseCodeReview::CommitTopic.create!(topic_id: topic.id, sha: 'a commit sha')
         end
       end
 

--- a/spec/requests/discourse_code_review/code_review_controller_spec.rb
+++ b/spec/requests/discourse_code_review/code_review_controller_spec.rb
@@ -3,13 +3,13 @@
 require 'rails_helper'
 
 describe DiscourseCodeReview::CodeReviewController do
+  fab!(:topic) { Fabricate(:topic) }
+  before_all do
+    topic.upsert_custom_fields(DiscourseCodeReview::COMMIT_HASH => '6a5aecee1234')
+    DiscourseCodeReview::CommitTopic.create!(topic_id: topic.id, sha: '6a5aecee1234')
+  end
 
   context "when not staff" do
-    fab!(:topic) { Fabricate(:topic) }
-    before do
-      topic.upsert_custom_fields(DiscourseCodeReview::COMMIT_HASH => '6a5aecee1234')
-    end
-
     it "returns 404 for anonymous users" do
       get '/code-review/redirect/6a5aecee'
       expect(response.status).to eq(404)
@@ -46,16 +46,11 @@ describe DiscourseCodeReview::CodeReviewController do
 
     context ".redirect" do
       it "will return 404 if that sha1 doesn't exist" do
-        get '/code-review/redirect/6a5aecee'
+        get '/code-review/redirect/deadbeef'
         expect(response.status).to eq(404)
       end
 
       context "with a sha1 that exists" do
-        fab!(:topic) { Fabricate(:topic) }
-        before do
-          topic.upsert_custom_fields(DiscourseCodeReview::COMMIT_HASH => '6a5aecee1234')
-        end
-
         it "will return 404 for a short sha1" do
           get '/code-review/redirect/6a5aec'
           expect(response.status).to eq(404)


### PR DESCRIPTION
This version still writes the data to custom fields for easier
reversion, just in case.