### PR TITLE
DEV: Add compatibility for Rails 7.0+

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -20,8 +20,6 @@ enabled_site_setting :code_review_enabled
 register_asset 'stylesheets/code_review.scss'
 register_svg_icon 'history'
 
-require_dependency 'auth/github_authenticator'
-require_dependency 'lib/staff_constraint'
 require File.expand_path("../lib/discourse_code_review/rake_tasks.rb", __FILE__)
 
 module HackGithubAuthenticator


### PR DESCRIPTION
As we’re upgrading Discourse to Rails 7.0.1, the way the autoloader was working previously changed a bit. We have weird stuff in some places like requiring files from `lib/` with the `lib` prefix which shouldn’t happen.

As the current version of Discourse already autoloads its `lib` folder, the `require_dependency` calls we have in this plugin aren’t useful anymore.

This patch removes these calls which leaves the plugin compatible with the current version of Discourse and makes it compatible with the changes that are going to be introduced when upgrading to Rails 7.0.1.

----

Rails 7 upgrade PR for reference: https://github.com/discourse/discourse/pull/15649 (WIP at the time of writing)