### PR TITLE
FIX: Add skip_draft to PostCreator calls

### DIFF
--- a/lib/discourse_code_review/github_pr_syncer.rb
+++ b/lib/discourse_code_review/github_pr_syncer.rb
@@ -198,6 +198,7 @@ module DiscourseCodeReview
         nonce_value: github_id,
         raw: raw,
         skip_validations: true,
+        skip_draft: true,
         tags: [SiteSetting.code_review_pull_request_tag],
         title: topic_title,
         user: author,

--- a/lib/discourse_code_review/state/commit_topics.rb
+++ b/lib/discourse_code_review/state/commit_topics.rb
@@ -115,6 +115,7 @@ module DiscourseCodeReview
                 category: category_id,
                 tags: tags,
                 skip_validations: true,
+                skip_draft: true,
               )
 
               TopicCustomField.create!(


### PR DESCRIPTION
It has to be merged after https://github.com/discourse/discourse/pull/15720.