### PR TITLE
FIX: Be more strict when matching Git trailers

### DIFF
--- a/lib/discourse_code_review/state/commit_topics.rb
+++ b/lib/discourse_code_review/state/commit_topics.rb
@@ -211,7 +211,7 @@ module DiscourseCodeReview
       end
 
       def escape_trailers(body)
-        return body if body !~ /\n\n(?:.*[:=].*\n?)+.\z/mi
+        return body if body !~ /\n\n(?:\S+: .+\n?)+\Z/mi
         first, separator, last = body.rpartition("\n\n")
         "#{first}#{separator}[code]\n#{last.strip}\n[/code]"
       end

--- a/spec/discourse_code_review/lib/importer_spec.rb
+++ b/spec/discourse_code_review/lib/importer_spec.rb
@@ -294,5 +294,44 @@ module DiscourseCodeReview
       <small>sha: 154f503d2e99f904356b52f2fae9edcc495708fa</small></p>
       HTML
     end
+
+    it "escapes correct Git trailers" do
+      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil, repo_id: 24)
+      repo.expects(:default_branch_contains?).with('154f503d2e99f904356b52f2fae9edcc495708fa').returns(true)
+      repo.expects(:followees).with('154f503d2e99f904356b52f2fae9edcc495708fa').returns([])
+
+      body = <<~TEXT
+      Discourse
+
+      http://discourse.org
+      TEXT
+
+      commit = {
+        subject: "hello world",
+        body: body,
+        email: "sam@sam.com",
+        github_login: "sam",
+        github_id: "111",
+        date: 1.day.ago,
+        diff: "```\nwith a diff",
+        hash: "154f503d2e99f904356b52f2fae9edcc495708fa"
+      }
+
+      topic = Topic.find(Importer.new(repo).import_commit(commit))
+      expect(topic.tags.pluck(:name)).not_to include(SiteSetting.code_review_approved_tag)
+      expect(topic.posts.pluck_first(:cooked)).to match_html <<~HTML
+      <div class="excerpt">
+        <p>Discourse</p>
+        <p><a href="http://discourse.org">http://discourse.org</a></p>
+      </div>
+
+      <pre><code class="lang-diff">`‍``
+        with a diff
+      </code></pre>
+
+      <p><a href="https://github.com/discourse/discourse/commit/154f503d2e99f904356b52f2fae9edcc495708fa">GitHub</a><br>
+      <small>sha: 154f503d2e99f904356b52f2fae9edcc495708fa</small></p>
+      HTML
+    end
   end
 end


### PR DESCRIPTION
Previous regex matched last paragraphs with ':' or '=' on every line.
This new regex checks if all lines from the last paragraph have a word,
the separator ': ' and another string.