### PR TITLE
DEV: Use `setup_git_repo` helper to avoid warnings

### DIFF
--- a/spec/discourse_code_review/lib/github_repo_spec.rb
+++ b/spec/discourse_code_review/lib/github_repo_spec.rb
@@ -19,16 +19,12 @@ module DiscourseCodeReview
     around(:each) do |example|
       with_tmpdir do |checkout_path|
         @checkout_path = checkout_path
-        with_tmpdir do |origin_path|
-          @origin_path = origin_path
+        @origin_path = setup_git_repo({})
 
-          `git init #{origin_path}`
-          system("git checkout -q -b main", chdir: origin_path)
-          DiscourseCodeReview::Source::GitRepo.new(origin_path, checkout_path)
+        DiscourseCodeReview::Source::GitRepo.new(origin_path, checkout_path)
 
-          Dir.chdir(checkout_path) do
-            example.run
-          end
+        Dir.chdir(checkout_path) do
+          example.run
         end
       end
     end

--- a/spec/helpers/remote_mocks.rb
+++ b/spec/helpers/remote_mocks.rb
@@ -2,14 +2,16 @@
 
 module RemoteMocks
   class << self
+    include Helpers
+
     def repos
       @repos ||= []
     end
 
     def make_repo
-      path = "/tmp/#{SecureRandom.hex}"
+      path = setup_git_repo({})
       repos << path
-      Rugged::Repository.init_at(path)
+      Rugged::Repository.new(path)
     end
 
     def cleanup!


### PR DESCRIPTION
```
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint: 	git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint: 	git branch -m <name>
```