### PR TITLE
FIX: Show error if plugin is not configured

### DIFF
--- a/app/controllers/discourse_code_review/repos_controller.rb
+++ b/app/controllers/discourse_code_review/repos_controller.rb
@@ -8,7 +8,7 @@ module DiscourseCodeReview
     def index
       repository_names = client.organization_repositories(organization).map(&:name)
       render_json_dump(repository_names)
-    rescue Octokit::Unauthorized
+    rescue DiscourseCodeReview::APIUserError, Octokit::Unauthorized
       render json: failed_json.merge(
         error: I18n.t("discourse_code_review.bad_github_credentials_error")
       ), status: 401

--- a/spec/requests/discourse_code_review/repos_controller_spec.rb
+++ b/spec/requests/discourse_code_review/repos_controller_spec.rb
@@ -64,6 +64,20 @@ describe DiscourseCodeReview::ReposController do
     end
 
     context "#index" do
+      context "when the plugin is not configured" do
+        before do
+          SiteSetting.code_review_github_token = ''
+          SiteSetting.code_review_github_webhook_secret = ''
+        end
+
+        it "returns a friendly error to the client" do
+          get '/admin/plugins/code-review/organizations/org/repos.json'
+          expect(JSON.parse(response.body)).to eq(
+            'error' => I18n.t("discourse_code_review.bad_github_credentials_error"), 'failed' => "FAILED"
+          )
+        end
+      end
+
       context "when the API returns Octokit::Unauthorized" do
         let!(:client) do
           client = mock

--- a/spec/requests/discourse_code_review/repos_controller_spec.rb
+++ b/spec/requests/discourse_code_review/repos_controller_spec.rb
@@ -72,7 +72,7 @@ describe DiscourseCodeReview::ReposController do
 
         it "returns a friendly error to the client" do
           get '/admin/plugins/code-review/organizations/org/repos.json'
-          expect(JSON.parse(response.body)).to eq(
+          expect(response.parsed_body).to eq(
             'error' => I18n.t("discourse_code_review.bad_github_credentials_error"), 'failed' => "FAILED"
           )
         end


### PR DESCRIPTION
The plugin returned a 500 because of an unhandled exception.