### PR TITLE
FIX: Allow deleted topics to be imported again

### DIFF
--- a/lib/discourse_code_review/state/commit_topics.rb
+++ b/lib/discourse_code_review/state/commit_topics.rb
@@ -117,12 +117,17 @@ module DiscourseCodeReview
                 skip_validations: true,
               )
 
+              TopicCustomField.where(
+                name: DiscourseCodeReview::COMMIT_HASH,
+                value: commit[:hash]
+              ).destroy_all
               TopicCustomField.create!(
                 topic_id: post.topic_id,
                 name: DiscourseCodeReview::COMMIT_HASH,
                 value: commit[:hash]
               )
 
+              CommitTopic.where(sha: commit[:hash]).destroy_all
               CommitTopic.create!(
                 topic_id: post.topic_id,
                 sha: commit[:hash],


### PR DESCRIPTION
It used to not work if a commit's topic was deleted and then the same
commit was imported again.