### PR TITLE
FIX: handle commits without messages

### DIFF
--- a/lib/discourse_code_review/state/commit_topics.rb
+++ b/lib/discourse_code_review/state/commit_topics.rb
@@ -63,7 +63,7 @@ module DiscourseCodeReview
               [GitHub](https://github.com/#{repo_name}/commit/#{commit[:hash]})
             LINK
 
-            title = commit[:subject]
+            title = commit[:subject].presence || "No message for commit #{commit[:hash][0, 8]}"
             # we add a unicode zero width joiner so code block is not corrupted
             diff = commit[:diff].gsub('```', "`\u200d``")
 

--- a/spec/discourse_code_review/lib/state/commit_topics_spec.rb
+++ b/spec/discourse_code_review/lib/state/commit_topics_spec.rb
@@ -46,6 +46,32 @@ module DiscourseCodeReview
       fab!(:user) { Fabricate(:user) }
       fab!(:category) { Fabricate(:category) }
 
+      it "can handle commits without message" do
+        commit = {
+          subject: "",
+          body: "",
+          email: "re@gis.com",
+          github_login: "regis",
+          github_id: "123",
+          date: 10.day.ago,
+          diff: "```\nwith a diff",
+          hash: "1cd4e0bec9ebd50f353a52b9c197f713c0e1f422"
+        }
+
+        repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil, repo_id: 24)
+
+        topic_id = State::CommitTopics.ensure_commit(
+          category_id: category.id,
+          commit: commit,
+          merged: false,
+          repo_name: repo.name,
+          user: user,
+          followees: []
+        )
+
+        expect(Topic.find_by(id: topic_id).title).to start_with("No message for commit ")
+      end
+
       it "can handle deleted topics" do
         commit = {
           subject: "hello world",


### PR DESCRIPTION
Automatically set a default title when the commit has no messages.