### PR TITLE
DEV: Log debug info about auto GitHub approvals

### DIFF
--- a/app/controllers/discourse_code_review/code_review_controller.rb
+++ b/app/controllers/discourse_code_review/code_review_controller.rb
@@ -51,6 +51,7 @@ module DiscourseCodeReview
       end
 
       if type == "push"
+        Rails.logger.warn("[DiscourseCodeReview::CodeReviewController#webhook] Enuqueuing code_review_sync_commits with repo_name = #{repo_name}, repo_id = #{repo_id}") if SiteSetting.code_review_debug
         ::Jobs.enqueue(:code_review_sync_commits, repo_name: repo_name, repo_id: repo_id)
       end
 

--- a/app/jobs/regular/code_review_sync_commits.rb
+++ b/app/jobs/regular/code_review_sync_commits.rb
@@ -17,6 +17,7 @@ module Jobs
 
       importer.sync_merged_commits do |commit_hash|
         if SiteSetting.code_review_approve_approved_prs
+          Rails.logger.warn("[Jobs::CodeReviewSyncCommits] Applying Github approves for repo_name = #{repo_name}, commit_hash = #{commit_hash}") if SiteSetting.code_review_debug
           DiscourseCodeReview
             .github_pr_syncer
             .apply_github_approves(repo_name, commit_hash)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,3 +43,6 @@ plugins:
   code_review_theme:
     client: true
     default: false
+  code_review_debug:
+    default: false
+    hidden: true

--- a/lib/discourse_code_review/github_pr_syncer.rb
+++ b/lib/discourse_code_review/github_pr_syncer.rb
@@ -84,9 +84,11 @@ module DiscourseCodeReview
           .where(code_review_commit_topics: { sha: commit_hash })
           .first
 
+      Rails.logger.warn("[DiscourseCodeReview::GithubPRSyncer#apply_github_approves] [commit_hash = #{commit_hash}] topic.id = #{topic&.id}") if SiteSetting.code_review_debug
       if topic
         pr_service.associated_pull_requests(repo_name, commit_hash).each do |pr|
           merge_info = pr_service.merge_info(pr)
+          Rails.logger.warn("[DiscourseCodeReview::GithubPRSyncer#apply_github_approves] [commit_hash = #{commit_hash}] pr = #{pr.to_json}, merge_info = #{merge_info}") if SiteSetting.code_review_debug
           if merge_info[:merged_by]
             merged_by = ensure_actor(merge_info[:merged_by])
 
@@ -98,6 +100,7 @@ module DiscourseCodeReview
                   SiteSetting.code_review_allow_self_approval || topic.user_id != user.id
                 }
 
+            Rails.logger.warn("[DiscourseCodeReview::GithubPRSyncer#apply_github_approves] [commit_hash = #{commit_hash}] approvers = #{approvers}") if SiteSetting.code_review_debug
             State::CommitApproval.approve(
               topic,
               approvers,


### PR DESCRIPTION
After an approved PR is merged the commit topic that is created for the
associated commit is sometimes not automatically approved. We originally
thought it was a race condition because of reused Octokit client
instances, but that was not the problem. The additional debug
information will give more insight about what is happening inside the
auto approval process.