### PR TITLE
UX: separate profile buttons to fix hover state

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/user-activity-bottom/approval-given-button.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-activity-bottom/approval-given-button.hbs
@@ -1,0 +1,5 @@
+<li>
+  {{#link-to "userActivity.approval-given"}}
+    {{i18n "code_review.approval_given"}}
+  {{/link-to}}
+</li>

--- a/assets/javascripts/discourse/templates/connectors/user-activity-bottom/approval-pending-button.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-activity-bottom/approval-pending-button.hbs
@@ -1,9 +1,4 @@
 <li>
-  {{#link-to "userActivity.approval-given"}}
-    {{i18n "code_review.approval_given"}}
-  {{/link-to}}
-</li>
-<li>
   {{#link-to "userActivity.approval-pending"}}
     {{i18n "code_review.approval_pending"}}
   {{/link-to}}


### PR DESCRIPTION
Previously these were in the same connector, which meant they shared a parent `li` (the connector class). The shared `li` parent meant that hovering over one made them both get the hover state.

This commit separates them and eliminates the issue.

Before:

![image](https://user-images.githubusercontent.com/1681963/165181672-5d3df911-10f8-4f43-a482-f3f14d3eddbe.png)

After:

![Screen Shot 2022-04-25 at 5 54 35 PM](https://user-images.githubusercontent.com/1681963/165181856-eda93240-10e2-4a5d-a56d-682087ceea29.png)

