### PR TITLE
FIX: Escape Git trailers present in last paragraph

### DIFF
--- a/lib/discourse_code_review/state/commit_topics.rb
+++ b/lib/discourse_code_review/state/commit_topics.rb
@@ -216,7 +216,7 @@ module DiscourseCodeReview
       end
 
       def escape_trailers(body)
-        return body if body !~ /\n\n(?:\S+: .+\n?)+\Z/mi
+        return body if body !~ /\n\n(?:\S+: .+\n?)+\Z/i
         first, separator, last = body.rpartition("\n\n")
         "#{first}#{separator}[code]\n#{last.strip}\n[/code]"
       end

--- a/lib/discourse_code_review/state/commit_topics.rb
+++ b/lib/discourse_code_review/state/commit_topics.rb
@@ -216,9 +216,13 @@ module DiscourseCodeReview
       end
 
       def escape_trailers(body)
-        return body if body !~ /\n\n(?:\S+: .+\n?)+\Z/i
         first, separator, last = body.rpartition("\n\n")
-        "#{first}#{separator}[code]\n#{last.strip}\n[/code]"
+        return body if first.blank?
+
+        last.strip!
+        return body if last !~ /(?:\S+: .+\n?)+\Z/i
+
+        "#{first}#{separator}[code]\n#{last}\n[/code]"
       end
     end
   end

--- a/spec/discourse_code_review/lib/importer_spec.rb
+++ b/spec/discourse_code_review/lib/importer_spec.rb
@@ -302,6 +302,51 @@ module DiscourseCodeReview
       HTML
     end
 
+    it "escapes Git trailers only if present in last paragraph" do
+      topic = Fabricate(:topic)
+      topic.custom_fields[DiscourseCodeReview::COMMIT_HASH] = "dbbadb5c357bc23daf1fa732f8670e55dc28b7cb"
+      topic.save
+      CommitTopic.create!(topic_id: topic.id, sha: "dbbadb5c357bc23daf1fa732f8670e55dc28b7cb")
+
+      repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil, repo_id: 24)
+      repo.expects(:default_branch_contains?).with('154f503d2e99f904356b52f2fae9edcc495708fa').returns(true)
+      repo.expects(:followees).with('154f503d2e99f904356b52f2fae9edcc495708fa').returns([])
+
+      body = <<~TEXT
+      Commit title
+
+      example: https://example.com
+
+      Lorem ipsum
+      TEXT
+
+      commit = {
+        subject: "hello world",
+        body: body,
+        email: "sam@sam.com",
+        github_login: "sam",
+        github_id: "111",
+        date: 1.day.ago,
+        diff: "```\nwith a diff",
+        hash: "154f503d2e99f904356b52f2fae9edcc495708fa"
+      }
+
+      topic = Topic.find(Importer.new(repo).import_commit(commit))
+      expect(topic.tags.pluck(:name)).not_to include(SiteSetting.code_review_approved_tag)
+      expect(topic.posts.pluck_first(:cooked)).to match_html <<~HTML
+        <div class="excerpt">
+        <p>Commit title</p>
+        <p>example: <a href="https://example.com">https://example.com</a></p>
+        <p>Lorem ipsum</p>
+        </div>
+        <pre><code class="lang-diff">`‍``
+        with a diff
+        </code></pre>
+        <p><a href="https://github.com/discourse/discourse/commit/154f503d2e99f904356b52f2fae9edcc495708fa">GitHub</a><br>
+        <small>sha: 154f503d2e99f904356b52f2fae9edcc495708fa</small></p>
+      HTML
+    end
+
     it "escapes correct Git trailers" do
       repo = GithubRepo.new("discourse/discourse", Octokit::Client.new, nil, repo_id: 24)
       repo.expects(:default_branch_contains?).with('154f503d2e99f904356b52f2fae9edcc495708fa').returns(true)


### PR DESCRIPTION
The previous regular expression looked for Git trailers in the whole
commit message, not only in the last paragraph. For example, it escaped
the last paragraph if the first paragraph was "foo: bar".