### PR TITLE
FIX: Wait 30 seconds before syncing commits

### DIFF
--- a/app/controllers/discourse_code_review/code_review_controller.rb
+++ b/app/controllers/discourse_code_review/code_review_controller.rb
@@ -52,7 +52,7 @@ module DiscourseCodeReview
 
       if type == "push"
         Rails.logger.warn("[DiscourseCodeReview::CodeReviewController#webhook] Enuqueuing code_review_sync_commits with repo_name = #{repo_name}, repo_id = #{repo_id}") if SiteSetting.code_review_debug
-        ::Jobs.enqueue(:code_review_sync_commits, repo_name: repo_name, repo_id: repo_id)
+        ::Jobs.enqueue_in(30.seconds, :code_review_sync_commits, repo_name: repo_name, repo_id: repo_id)
       end
 
       if type == "commit_comment"

--- a/app/jobs/regular/code_review_sync_commits.rb
+++ b/app/jobs/regular/code_review_sync_commits.rb
@@ -17,7 +17,7 @@ module Jobs
 
       importer.sync_merged_commits do |commit_hash|
         if SiteSetting.code_review_approve_approved_prs
-          Rails.logger.warn("[Jobs::CodeReviewSyncCommits] Applying Github approves for repo_name = #{repo_name}, commit_hash = #{commit_hash}") if SiteSetting.code_review_debug
+          Rails.logger.warn("[DiscourseCodeReview] [Jobs::CodeReviewSyncCommits] Applying Github approves for repo_name = #{repo_name}, commit_hash = #{commit_hash}") if SiteSetting.code_review_debug
           DiscourseCodeReview
             .github_pr_syncer
             .apply_github_approves(repo_name, commit_hash)


### PR DESCRIPTION
Some commits are not automatically approved even if they follow all the
requirements necessary for that. Running the same sync process again at
a later time seems to work as expected.

This commits adds a 30 seconds delay between the time the merge webhook
is received and the time the sync process happens. If this is just a
timing issue, this delay should fix that.