### PR TITLE
DEV: Remove 'htmlSafe' string prototype extensions

### DIFF
--- a/assets/javascripts/discourse/components/review-topic-list-item.js
+++ b/assets/javascripts/discourse/components/review-topic-list-item.js
@@ -1,13 +1,14 @@
 import { findRawTemplate } from "discourse-common/lib/raw-templates";
 import { observes } from "discourse-common/utils/decorators";
 import TopicListItem from "discourse/components/topic-list-item";
+import { htmlSafe } from "@ember/template";
 
 export default TopicListItem.extend({
   @observes("topic.pinned")
   renderTopicListItem() {
     const template = findRawTemplate("list/review-topic-list-item");
     if (template) {
-      this.set("topicListItemContents", template(this).htmlSafe());
+      this.set("topicListItemContents", htmlSafe(template(this)));
     }
   },
 });


### PR DESCRIPTION
## Ember Upgrade

Context: https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions