### PR TITLE
FIX: Rename `can_review` to `can_review_code`

### DIFF
--- a/app/controllers/discourse_code_review/code_review_controller.rb
+++ b/app/controllers/discourse_code_review/code_review_controller.rb
@@ -3,11 +3,11 @@
 module DiscourseCodeReview
   class CodeReviewController < ::ApplicationController
     before_action :ensure_logged_in
-    before_action :ensure_can_review
+    before_action :ensure_can_review_code
 
     skip_before_action :verify_authenticity_token, only: :webhook
     skip_before_action :ensure_logged_in, only: :webhook
-    skip_before_action :ensure_can_review, only: :webhook
+    skip_before_action :ensure_can_review_code, only: :webhook
     skip_before_action :redirect_to_login_if_required, only: :webhook
     skip_before_action :check_xhr, only: [:webhook, :redirect]
 
@@ -219,8 +219,8 @@ module DiscourseCodeReview
       }
     end
 
-    def ensure_can_review
-      raise Discourse::InvalidAccess.new unless current_user && current_user.can_review?
+    def ensure_can_review_code
+      raise Discourse::InvalidAccess.new unless current_user && current_user.can_review_code?
     end
   end
 end

--- a/assets/javascripts/discourse/initializers/init-code-review.js
+++ b/assets/javascripts/discourse/initializers/init-code-review.js
@@ -115,7 +115,7 @@ function initialize(api) {
     dependentKeys: ["topic.tags"],
     displayed() {
       return (
-        this.get("currentUser.can_review") &&
+        this.get("currentUser.can_review_code") &&
         allowApprove(this.currentUser, this.topic, this.siteSettings)
       );
     },
@@ -137,7 +137,7 @@ function initialize(api) {
     dependentKeys: ["topic.tags"],
     displayed() {
       return (
-        this.get("currentUser.can_review") &&
+        this.get("currentUser.can_review_code") &&
         allowSkip(this.currentUser, this.topic, this.siteSettings)
       );
     },
@@ -159,7 +159,7 @@ function initialize(api) {
     dependentKeys: ["topic.tags"],
     displayed() {
       return (
-        this.get("currentUser.can_review") &&
+        this.get("currentUser.can_review_code") &&
         allowFollowupButton(this.topic, this.siteSettings)
       );
     },
@@ -181,7 +181,7 @@ function initialize(api) {
     dependentKeys: ["topic.tags"],
     displayed() {
       return (
-        this.get("currentUser.can_review") &&
+        this.get("currentUser.can_review_code") &&
         allowFollowedUpButton(this.currentUser, this.topic, this.siteSettings)
       );
     },

--- a/lib/discourse_code_review/github_pr_syncer.rb
+++ b/lib/discourse_code_review/github_pr_syncer.rb
@@ -95,7 +95,7 @@ module DiscourseCodeReview
             approvers =
               merge_info[:approvers]
                 .map(&method(:ensure_actor))
-                .select(&:can_review?)
+                .select(&:can_review_code?)
                 .select { |user|
                   SiteSetting.code_review_allow_self_approval || topic.user_id != user.id
                 }

--- a/lib/discourse_code_review/state/commit_approval.rb
+++ b/lib/discourse_code_review/state/commit_approval.rb
@@ -29,7 +29,7 @@ module DiscourseCodeReview::State::CommitApproval
         transition_to_approved(topic) do
           send_approved_notification(topic, last_post)
 
-          if SiteSetting.code_review_auto_unassign_on_approve && topic.user.can_review?
+          if SiteSetting.code_review_auto_unassign_on_approve && topic.user.can_review_code?
             DiscourseEvent.trigger(:unassign_topic, topic, approvers.first)
           end
         end
@@ -61,7 +61,7 @@ module DiscourseCodeReview::State::CommitApproval
           action_code: "followup"
         )
 
-        if SiteSetting.code_review_auto_assign_on_followup && topic.user.can_review?
+        if SiteSetting.code_review_auto_assign_on_followup && topic.user.can_review_code?
           DiscourseEvent.trigger(:assign_topic, topic, topic.user, actor)
         end
       end
@@ -80,7 +80,7 @@ module DiscourseCodeReview::State::CommitApproval
       transition_to_approved(followee_topic) do
         send_approved_notification(followee_topic, last_post)
 
-        if SiteSetting.code_review_auto_unassign_on_approve && followee_topic.user.can_review?
+        if SiteSetting.code_review_auto_unassign_on_approve && followee_topic.user.can_review_code?
           DiscourseEvent.trigger(
             :unassign_topic,
             followee_topic,

--- a/plugin.rb
+++ b/plugin.rb
@@ -267,8 +267,8 @@ after_initialize do
     end
   end
 
-  add_to_class(:user, :can_review?) do
-    @can_review ||= begin
+  add_to_class(:user, :can_review_code?) do
+    @can_review_code ||= begin
       if admin?
         :true
       else
@@ -277,11 +277,11 @@ after_initialize do
       end
     end
 
-    @can_review == :true
+    @can_review_code == :true
   end
 
-  add_to_serializer(:current_user, :can_review) do
-    object.can_review?
+  add_to_serializer(:current_user, :can_review_code) do
+    object.can_review_code?
   end
 
   require_dependency 'list_controller'

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -194,7 +194,7 @@ describe DiscourseCodeReview do
     end
   end
 
-  describe 'can_review?' do
+  describe 'can_review_code?' do
     fab!(:group) { Fabricate(:group) }
     fab!(:user) { Fabricate(:user) }
 
@@ -205,15 +205,15 @@ describe DiscourseCodeReview do
     it 'returns true for user in allowed groups' do
       SiteSetting.code_review_allowed_groups = "#{group.id}"
 
-      expect(user.can_review?).to eq(false)
+      expect(user.can_review_code?).to eq(false)
 
       group.add(user)
-      expect(User.find(user.id).can_review?).to eq(true)
+      expect(User.find(user.id).can_review_code?).to eq(true)
     end
 
     it 'returns true for admins' do
-      expect(Fabricate(:admin).can_review?).to eq(true)
-      expect(user.can_review?).to eq(false)
+      expect(Fabricate(:admin).can_review_code?).to eq(true)
+      expect(user.can_review_code?).to eq(false)
     end
   end
 

--- a/test/javascripts/acceptance/self-approve-desktop-test.js
+++ b/test/javascripts/acceptance/self-approve-desktop-test.js
@@ -9,7 +9,9 @@ import { test } from "qunit";
 import { cloneJSON } from "discourse-common/lib/object";
 
 acceptance("review desktop", function (needs) {
-  needs.user();
+  needs.user({
+    can_review_code: true,
+  });
   needs.settings({
     code_review_approved_tag: "approved",
     code_review_pending_tag: "pending",

--- a/test/javascripts/acceptance/self-approve-mobile-test.js
+++ b/test/javascripts/acceptance/self-approve-mobile-test.js
@@ -9,7 +9,9 @@ import { test } from "qunit";
 import { cloneJSON } from "discourse-common/lib/object";
 
 acceptance("review mobile", function (needs) {
-  needs.user();
+  needs.user({
+    can_review_code: true,
+  });
   needs.mobileView();
   needs.settings({
     code_review_approved_tag: "approved",


### PR DESCRIPTION
`CurrentUserSerializer` in core has a `can_review` attribute that's used to check if the user can see the Review link in the hamburger menu:

https://github.com/discourse/discourse/blob/010bb20f53cc81068824fc278c457ef1739f25e7/app/serializers/current_user_serializer.rb#L263-L265

However, this plugin adds an attribute with the same name to the serializer which overrides (inadvertently) core's definition of the attribute and results in issues such as users not being able to see the Review link if the plugin is disabled. This PR renames `can_review` to `can_review_code` everywhere in the plugin to avoid conflicts with core.