### PR TITLE
DEV: Add support for the experimental user menu

### DIFF
--- a/assets/javascripts/discourse/widgets/code-review-commit-approved-notification-item.js
+++ b/assets/javascripts/discourse/widgets/code-review-commit-approved-notification-item.js
@@ -1,11 +1,8 @@
 import { createWidgetFrom } from "discourse/widgets/widget";
 import { DefaultNotificationItem } from "discourse/widgets/default-notification-item";
-import { replaceIcon } from "discourse-common/lib/icon-library";
 import { postUrl } from "discourse/lib/utilities";
 import { userPath } from "discourse/lib/url";
 import I18n from "I18n";
-
-replaceIcon("notification.code_review_commit_approved", "check");
 
 createWidgetFrom(
   DefaultNotificationItem,
@@ -24,7 +21,7 @@ createWidgetFrom(
         });
       } else {
         return I18n.t("notifications.code_review.commit_approved.multiple", {
-          numApprovedCommits,
+          count: numApprovedCommits,
         });
       }
     },

--- a/config/locales/client.ar.yml
+++ b/config/locales/client.ar.yml
@@ -17,7 +17,7 @@ ar:
       code_review:
         commit_approved:
           single: 'تمت الموافقة على "%{topicTitle}"'
-          multiple: "تمت الموافقة على %{numApprovedCommits} من الإرسالات"
+          multiple: "تمت الموافقة على %{count} من الإرسالات"
           title: "تمت الموافقة على الإرسال"
     code_review:
       title: "مراجعة الرمز"

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -17,7 +17,7 @@ de:
       code_review:
         commit_approved:
           single: '„%{topicTitle}“ genehmigt'
-          multiple: "%{numApprovedCommits} Commits wurden genehmigt"
+          multiple: "%{count} Commits wurden genehmigt"
           title: "Commit genehmigt"
     code_review:
       title: "Code-Review"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -11,7 +11,9 @@ en:
       code_review:
         commit_approved:
           single: '"%{topicTitle}" approved'
-          multiple: "%{numApprovedCommits} commits were approved"
+          multiple:
+            one: "%{count} commit was approved"
+            other: "%{count} commits were approved"
           title: "commit approved"
     code_review:
       title: "Code Review"

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -17,7 +17,7 @@ es:
       code_review:
         commit_approved:
           single: '«%{topicTitle}» aprobado'
-          multiple: "Se aprobaron %{numApprovedCommits} commits"
+          multiple: "Se aprobaron %{count} commits"
           title: "commit aprobada"
     code_review:
       title: "Revisión de código"

--- a/config/locales/client.fi.yml
+++ b/config/locales/client.fi.yml
@@ -17,7 +17,7 @@ fi:
       code_review:
         commit_approved:
           single: '"%{topicTitle}" hyväksytty'
-          multiple: "%{numApprovedCommits} solmua hyväksyttiin"
+          multiple: "%{count} solmua hyväksyttiin"
           title: "solmu hyväksytty"
     code_review:
       title: "Koodin tarkistus"

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -17,7 +17,7 @@ fr:
       code_review:
         commit_approved:
           single: '« %{topicTitle} » approuvé'
-          multiple: "%{numApprovedCommits} commits ont été approuvés"
+          multiple: "%{count} commits ont été approuvés"
           title: "commit approuvé"
     code_review:
       title: "Examen du code"

--- a/config/locales/client.he.yml
+++ b/config/locales/client.he.yml
@@ -17,7 +17,7 @@ he:
       code_review:
         commit_approved:
           single: '„%{topicTitle}” קיבל אישור'
-          multiple: "%{numApprovedCommits} הגשות קיבלו אישור"
+          multiple: "%{count} הגשות קיבלו אישור"
           title: "ההגשה אושרה"
     code_review:
       title: "סקירת קוד"

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -17,7 +17,7 @@ it:
       code_review:
         commit_approved:
           single: '"%{topicTitle}" approvato'
-          multiple: "%{numApprovedCommits} commit sono stati approvati"
+          multiple: "%{count} commit sono stati approvati"
           title: "commit approvato"
     code_review:
       title: "Revisione del codice"

--- a/config/locales/client.ja.yml
+++ b/config/locales/client.ja.yml
@@ -17,7 +17,7 @@ ja:
       code_review:
         commit_approved:
           single: '「%{topicTitle}」が承認されました'
-          multiple: "%{numApprovedCommits} 件のコミットが承認されました"
+          multiple: "%{count} 件のコミットが承認されました"
           title: "コミットが承認されました"
     code_review:
       title: "コードレビュー"

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -17,7 +17,7 @@ pt_BR:
       code_review:
         commit_approved:
           single: 'Aprovou "%{topicTitle}"'
-          multiple: "%{numApprovedCommits} confirmações foram aprovadas"
+          multiple: "%{count} confirmações foram aprovadas"
           title: "confirmação aprovada"
     code_review:
       title: "Revisão de código"

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -17,7 +17,7 @@ ru:
       code_review:
         commit_approved:
           single: 'Коммит «%{topicTitle}» одобрен'
-          multiple: "%{numApprovedCommits} коммитов было одобрено"
+          multiple: "%{count} коммитов было одобрено"
           title: "Коммит одобрен"
     code_review:
       title: "Проверка кода"

--- a/config/locales/client.sv.yml
+++ b/config/locales/client.sv.yml
@@ -17,7 +17,7 @@ sv:
       code_review:
         commit_approved:
           single: '"%{topicTitle}" har godkänts'
-          multiple: "%{numApprovedCommits} åtaganden godkändes"
+          multiple: "%{count} åtaganden godkändes"
           title: "åtagande godkänt"
     code_review:
       title: "Kodgranskning"

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -17,7 +17,7 @@ zh_CN:
       code_review:
         commit_approved:
           single: '“%{topicTitle}”已被批准'
-          multiple: "%{numApprovedCommits} 项提交已被批准"
+          multiple: "%{count} 项提交已被批准"
           title: "提交已被批准"
     code_review:
       title: "代码审查"

--- a/test/javascripts/acceptance/commit-approved-notifications-test.js
+++ b/test/javascripts/acceptance/commit-approved-notifications-test.js
@@ -1,0 +1,90 @@
+import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import { click, visit } from "@ember/test-helpers";
+import I18n from "I18n";
+
+acceptance("Discourse Calendar - Notifications", function (needs) {
+  needs.user({ redesigned_user_menu_enabled: true });
+  needs.settings({ calendar_enabled: true });
+
+  needs.pretender((server, helper) => {
+    server.get("/notifications", () => {
+      return helper.response({
+        notifications: [
+          {
+            id: 801,
+            user_id: 12,
+            notification_type: 21, // code_review_commit_approved notification type
+            read: true,
+            high_priority: false,
+            created_at: "2001-10-17 15:41:10 UTC",
+            post_number: 1,
+            topic_id: 883,
+            fancy_title: "Commit #1",
+            slug: "commit-1",
+            data: {
+              num_approved_commits: 1,
+            },
+          },
+          {
+            id: 389,
+            user_id: 12,
+            notification_type: 21, // code_review_commit_approved notification type
+            read: true,
+            high_priority: false,
+            created_at: "2010-11-17 23:01:15 UTC",
+            post_number: null,
+            topic_id: null,
+            fancy_title: null,
+            slug: null,
+            data: {
+              num_approved_commits: 10,
+            },
+          },
+        ],
+      });
+    });
+  });
+
+  test("code review commit approved notifications", async function (assert) {
+    await visit("/");
+    await click(".d-header-icons .current-user");
+
+    const notifications = queryAll(
+      "#quick-access-all-notifications ul li.notification a"
+    );
+    assert.strictEqual(notifications.length, 2);
+
+    assert.strictEqual(
+      notifications[0].textContent.replaceAll(/\s+/g, " ").trim(),
+      I18n.t("notifications.code_review.commit_approved.single", {
+        topicTitle: "Commit #1",
+      }),
+      "notification for a single commit approval has the right content"
+    );
+    assert.ok(
+      notifications[0].href.endsWith("/t/commit-1/883"),
+      "notification for a single commit approval links to the topic"
+    );
+    assert.ok(
+      notifications[0].querySelector(".d-icon-check"),
+      "notification for a single commit approval has the right icon"
+    );
+
+    assert.strictEqual(
+      notifications[1].textContent.replaceAll(/\s+/g, " ").trim(),
+      I18n.t("notifications.code_review.commit_approved.multiple", {
+        count: 10,
+      }),
+      "notification for multiple commits approval has the right content"
+    );
+    assert.ok(
+      notifications[1].href.endsWith("/u/eviltrout/activity/approval-given"),
+      "notification for multiple commits approval links to the user approval-given page"
+    );
+    assert.ok(
+      notifications[1].querySelector(".d-icon-check"),
+      "notification for multiple commits approval has the right icon"
+    );
+  });
+});


### PR DESCRIPTION
This PR ports the widgets-based implementation of the `code_review_commit_approved` notification item to the experimental Glimmer-based user menu. The changes in this PR should make `code_review_commit_approved` notifications in the experimental user menu consistent with they look/behave in the old user menu.

We don't need to add a `.discourse-compatibility` entry for this change because it's fully backward compatible since we check that the `registerNotificationTypeRenderer` plugin API is available before we attempt to use it.

For more context on the experimental user menu, see https://github.com/discourse/discourse/pull/17379.