### PR TITLE
FIX: Periodically resync repos

### DIFF
--- a/app/jobs/regular/code_review_sync_commits.rb
+++ b/app/jobs/regular/code_review_sync_commits.rb
@@ -13,6 +13,19 @@ module Jobs
       github_commit_querier = DiscourseCodeReview.github_commit_querier
 
       repo = DiscourseCodeReview::GithubRepo.new(repo_name, client, github_commit_querier, repo_id: repo_id)
+
+      if args[:skip_if_updated]
+        begin
+          octokit_repo = client.repository(repo_name)
+          branch = client.branch(repo_name, octokit_repo.default_branch)
+          last_remote_commit = branch.commit.sha
+        rescue
+          Rails.logger.warn("Cannot fetch GitHub repo information for #{repo_name}")
+        end
+
+        return if repo.last_local_commit == last_remote_commit
+      end
+
       importer = DiscourseCodeReview::Importer.new(repo)
 
       importer.sync_merged_commits do |commit_hash|

--- a/app/jobs/regular/code_review_sync_commits.rb
+++ b/app/jobs/regular/code_review_sync_commits.rb
@@ -14,7 +14,7 @@ module Jobs
 
       repo = DiscourseCodeReview::GithubRepo.new(repo_name, client, github_commit_querier, repo_id: repo_id)
 
-      if args[:skip_if_updated]
+      if args[:skip_if_up_to_date]
         begin
           octokit_repo = client.repository(repo_name)
           branch = client.branch(repo_name, octokit_repo.default_branch)

--- a/app/jobs/scheduled/code_review_sync_repos.rb
+++ b/app/jobs/scheduled/code_review_sync_repos.rb
@@ -10,7 +10,7 @@ module Jobs
           :code_review_sync_commits,
           repo_name: repo_name,
           repo_id: repo_id,
-          skip_if_updated: true
+          skip_if_up_to_date: true
         )
       end
     end

--- a/app/jobs/scheduled/code_review_sync_repos.rb
+++ b/app/jobs/scheduled/code_review_sync_repos.rb
@@ -5,20 +5,13 @@ module Jobs
     every 1.hour
 
     def execute(args = {})
-      client = DiscourseCodeReview.octokit_bot_client
-      github_commit_querier = DiscourseCodeReview.github_commit_querier
-
-      DiscourseCodeReview::State::GithubRepoCategories.each_repo_name do |repo_name|
-        github_repo = DiscourseCodeReview::GithubRepo.new(repo_name, client, github_commit_querier)
-        octokit_repo = client.repository(repo_name)
-        branch = client.branch(repo_name, octokit_repo.default_branch)
-
-        last_local_commit = github_repo.last_local_commit
-        last_remote_commit = branch.commit.sha
-
-        if last_local_commit != last_remote_commit
-          ::Jobs.enqueue(:code_review_sync_commits, repo_name: repo_name)
-        end
+      DiscourseCodeReview::GithubRepoCategory.pluck(:name, :repo_id).each do |repo_name, repo_id|
+        ::Jobs.enqueue(
+          :code_review_sync_commits,
+          repo_name: repo_name,
+          repo_id: repo_id,
+          skip_if_updated: true
+        )
       end
     end
   end

--- a/app/jobs/scheduled/code_review_sync_repos.rb
+++ b/app/jobs/scheduled/code_review_sync_repos.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Jobs
+  class CodeReviewSyncRepos < ::Jobs::Scheduled
+    every 1.hour
+
+    def execute(args = nil)
+      DiscourseCodeReview::State::GithubRepoCategories.each_repo_name do |repo_name|
+        ::Jobs.enqueue(:code_review_sync_commits, repo_name: repo_name)
+      end
+    end
+  end
+end

--- a/app/jobs/scheduled/code_review_sync_repos.rb
+++ b/app/jobs/scheduled/code_review_sync_repos.rb
@@ -4,9 +4,21 @@ module Jobs
   class CodeReviewSyncRepos < ::Jobs::Scheduled
     every 1.hour
 
-    def execute(args = nil)
+    def execute(args = {})
+      client = DiscourseCodeReview.octokit_bot_client
+      github_commit_querier = DiscourseCodeReview.github_commit_querier
+
       DiscourseCodeReview::State::GithubRepoCategories.each_repo_name do |repo_name|
-        ::Jobs.enqueue(:code_review_sync_commits, repo_name: repo_name)
+        github_repo = DiscourseCodeReview::GithubRepo.new(repo_name, client, github_commit_querier)
+        octokit_repo = client.repository(repo_name)
+        branch = client.branch(repo_name, octokit_repo.default_branch)
+
+        last_local_commit = github_repo.last_local_commit
+        last_remote_commit = branch.commit.sha
+
+        if last_local_commit != last_remote_commit
+          ::Jobs.enqueue(:code_review_sync_commits, repo_name: repo_name)
+        end
       end
     end
   end

--- a/lib/discourse_code_review/github_repo.rb
+++ b/lib/discourse_code_review/github_repo.rb
@@ -23,8 +23,13 @@ module DiscourseCodeReview
       @default_branch ||= "origin/#{octokit_client.repository(@name)["default_branch"]}"
     end
 
+    def last_local_commit
+      PluginStore.get(DiscourseCodeReview::PluginName, LAST_COMMIT + @name)
+    end
+
     def last_commit
-      commit_hash = PluginStore.get(DiscourseCodeReview::PluginName, LAST_COMMIT + @name)
+      commit_hash = last_local_commit
+
       if commit_hash.present? && !commit_hash_valid?(commit_hash)
         Rails.logger.warn("Discourse Code Review: Failed to detect commit hash `#{commit_hash}` in #{path}, resetting last commit hash.")
         commit_hash = nil

--- a/plugin.rb
+++ b/plugin.rb
@@ -178,6 +178,7 @@ after_initialize do
   require File.expand_path("../app/models/commit_topic.rb", __FILE__)
   require File.expand_path("../app/jobs/regular/code_review_sync_commits", __FILE__)
   require File.expand_path("../app/jobs/regular/code_review_sync_commit_comments", __FILE__)
+  require File.expand_path("../app/jobs/scheduled/code_review_sync_repos", __FILE__)
   require File.expand_path("../lib/enumerators", __FILE__)
   require File.expand_path("../lib/typed_data", __FILE__)
   require File.expand_path("../lib/graphql_client", __FILE__)

--- a/spec/helpers/github_rest_api_mock.rb
+++ b/spec/helpers/github_rest_api_mock.rb
@@ -16,8 +16,8 @@ module GithubRestAPIMock
         }
     end
 
-    def declare_repo!(owner:, repo:, default_branch:)
-      infos[[owner, repo]] = { default_branch: default_branch }
+    def declare_repo!(owner:, repo:, default_branch:, last_commit:)
+      infos[[owner, repo]] = { default_branch: default_branch, commit: { sha: last_commit } }
     end
 
     def declare_commit_comment!(owner:, repo:, commit:, comment:)

--- a/spec/helpers/integration.rb
+++ b/spec/helpers/integration.rb
@@ -6,7 +6,7 @@ require_relative 'rugged_interceptor'
 require_relative 'github_rest_api_mock'
 
 module CodeReviewIntegrationHelpers
-  def declare_github_repo!(owner:, repo:, default_branch: "main", &blk)
+  def declare_github_repo!(owner:, repo:, default_branch: "main", last_commit: "abcdef", &blk)
     local = RemoteMocks.make_repo
 
     RuggedInterceptor::Repository.intercept(
@@ -17,7 +17,8 @@ module CodeReviewIntegrationHelpers
     GithubRestAPIMock.declare_repo!(
       owner: owner,
       repo: repo,
-      default_branch: default_branch
+      default_branch: default_branch,
+      last_commit: last_commit,
     )
 
     blk.call(local)

--- a/spec/jobs/code_review_sync_commits_spec.rb
+++ b/spec/jobs/code_review_sync_commits_spec.rb
@@ -11,6 +11,7 @@ describe Jobs::CodeReviewSyncCommits, type: :code_review_integration do
         owner: "10xninjarockstar",
         repo: "ultimatetodolist",
         default_branch: "main",
+        last_commit: "abcdef",
       ) do |repo|
         msg = "Initial commit"
 
@@ -46,6 +47,30 @@ describe Jobs::CodeReviewSyncCommits, type: :code_review_integration do
 
       hash = topics.first.custom_fields[DiscourseCodeReview::COMMIT_HASH]
       expect(commit_post.raw).to include("sha: #{hash}")
+    end
+
+    it "skips if last local and remote commit SHAs match" do
+      PluginStore.set(
+        DiscourseCodeReview::PluginName,
+        DiscourseCodeReview::GithubRepo::LAST_COMMIT + '10xninjarockstar/ultimatetodolist',
+        'abcdef'
+      )
+
+      expect {
+        described_class.new.execute(repo_name: '10xninjarockstar/ultimatetodolist', repo_id: 24, skip_if_updated: true)
+      }.to change { Topic.count }.by(0)
+    end
+
+    it "does not skips if last local and remote commit SHAs mismatch" do
+      PluginStore.set(
+        DiscourseCodeReview::PluginName,
+        DiscourseCodeReview::GithubRepo::LAST_COMMIT + '10xninjarockstar/ultimatetodolist',
+        'abcdeg'
+      )
+
+      expect {
+        described_class.new.execute(repo_name: '10xninjarockstar/ultimatetodolist', repo_id: 24, skip_if_updated: true)
+      }.to change { Topic.count }.by(2)
     end
   end
 end

--- a/spec/jobs/code_review_sync_commits_spec.rb
+++ b/spec/jobs/code_review_sync_commits_spec.rb
@@ -57,7 +57,7 @@ describe Jobs::CodeReviewSyncCommits, type: :code_review_integration do
       )
 
       expect {
-        described_class.new.execute(repo_name: '10xninjarockstar/ultimatetodolist', repo_id: 24, skip_if_updated: true)
+        described_class.new.execute(repo_name: '10xninjarockstar/ultimatetodolist', repo_id: 24, skip_if_up_to_date: true)
       }.to change { Topic.count }.by(0)
     end
 
@@ -69,7 +69,7 @@ describe Jobs::CodeReviewSyncCommits, type: :code_review_integration do
       )
 
       expect {
-        described_class.new.execute(repo_name: '10xninjarockstar/ultimatetodolist', repo_id: 24, skip_if_updated: true)
+        described_class.new.execute(repo_name: '10xninjarockstar/ultimatetodolist', repo_id: 24, skip_if_up_to_date: true)
       }.to change { Topic.count }.by(2)
     end
   end

--- a/spec/jobs/code_review_sync_repos_spec.rb
+++ b/spec/jobs/code_review_sync_repos_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../helpers/integration'
+
+describe Jobs::CodeReviewSyncRepos, type: :code_review_integration do
+  it "schedules sync jobs for all repos" do
+    DiscourseCodeReview::State::GithubRepoCategories.ensure_category(repo_name: "discourse", repo_id: 42)
+    DiscourseCodeReview::State::GithubRepoCategories.ensure_category(repo_name: "discourse-code-review", repo_id: 43)
+
+    expect { described_class.new.execute }
+      .to change { Jobs::CodeReviewSyncCommits.jobs.count }.by(2)
+  end
+end

--- a/spec/jobs/code_review_sync_repos_spec.rb
+++ b/spec/jobs/code_review_sync_repos_spec.rb
@@ -4,43 +4,11 @@ require 'rails_helper'
 require_relative '../helpers/integration'
 
 describe Jobs::CodeReviewSyncRepos, type: :code_review_integration do
-  before do
-    SiteSetting.code_review_github_token = 'code_review_github_token'
-
-    declare_github_repo!(
-      owner: 'discourse',
-      repo: 'discourse-code-review',
-      default_branch: 'main',
-      last_commit: 'abcdef',
-    ) do |repo|
-      msg = 'Initial commit'
-
-      Dir.chdir(repo.workdir) do
-        File.write('README.md', <<~EOF)
-          Just store text files with your todo list items.
-        EOF
-
-        `git add README.md`
-        `git commit -m 'Initial commit'`
-        `git branch -m main`
-
-        commit = `git rev-parse HEAD`
-      end
-    end
-  end
-
-  it 'schedules sync jobs for outdated repos' do
-    DiscourseCodeReview::State::GithubRepoCategories.ensure_category(repo_name: 'discourse/discourse-code-review', repo_id: 42)
+  it 'schedules sync jobs for all repos' do
+    DiscourseCodeReview::State::GithubRepoCategories.ensure_category(repo_name: 'discourse/discourse', repo_id: 42)
+    DiscourseCodeReview::State::GithubRepoCategories.ensure_category(repo_name: 'discourse/discourse-code-review', repo_id: 43)
 
     expect { described_class.new.execute }
-      .to change { Jobs::CodeReviewSyncCommits.jobs.count }.by(1)
-  end
-
-  it 'does not schedule sync jobs for updated repos' do
-    DiscourseCodeReview::State::GithubRepoCategories.ensure_category(repo_name: 'discourse/discourse-code-review', repo_id: 42)
-    PluginStore.set(DiscourseCodeReview::PluginName, DiscourseCodeReview::GithubRepo::LAST_COMMIT + 'discourse/discourse-code-review', 'abcdef')
-
-    expect { described_class.new.execute }
-      .to change { Jobs::CodeReviewSyncCommits.jobs.count }.by(0)
+      .to change { Jobs::CodeReviewSyncCommits.jobs.count }.by(2)
   end
 end

--- a/spec/jobs/code_review_sync_repos_spec.rb
+++ b/spec/jobs/code_review_sync_repos_spec.rb
@@ -4,11 +4,43 @@ require 'rails_helper'
 require_relative '../helpers/integration'
 
 describe Jobs::CodeReviewSyncRepos, type: :code_review_integration do
-  it "schedules sync jobs for all repos" do
-    DiscourseCodeReview::State::GithubRepoCategories.ensure_category(repo_name: "discourse", repo_id: 42)
-    DiscourseCodeReview::State::GithubRepoCategories.ensure_category(repo_name: "discourse-code-review", repo_id: 43)
+  before do
+    SiteSetting.code_review_github_token = 'code_review_github_token'
+
+    declare_github_repo!(
+      owner: 'discourse',
+      repo: 'discourse-code-review',
+      default_branch: 'main',
+      last_commit: 'abcdef',
+    ) do |repo|
+      msg = 'Initial commit'
+
+      Dir.chdir(repo.workdir) do
+        File.write('README.md', <<~EOF)
+          Just store text files with your todo list items.
+        EOF
+
+        `git add README.md`
+        `git commit -m 'Initial commit'`
+        `git branch -m main`
+
+        commit = `git rev-parse HEAD`
+      end
+    end
+  end
+
+  it 'schedules sync jobs for outdated repos' do
+    DiscourseCodeReview::State::GithubRepoCategories.ensure_category(repo_name: 'discourse/discourse-code-review', repo_id: 42)
 
     expect { described_class.new.execute }
-      .to change { Jobs::CodeReviewSyncCommits.jobs.count }.by(2)
+      .to change { Jobs::CodeReviewSyncCommits.jobs.count }.by(1)
+  end
+
+  it 'does not schedule sync jobs for updated repos' do
+    DiscourseCodeReview::State::GithubRepoCategories.ensure_category(repo_name: 'discourse/discourse-code-review', repo_id: 42)
+    PluginStore.set(DiscourseCodeReview::PluginName, DiscourseCodeReview::GithubRepo::LAST_COMMIT + 'discourse/discourse-code-review', 'abcdef')
+
+    expect { described_class.new.execute }
+      .to change { Jobs::CodeReviewSyncCommits.jobs.count }.by(0)
   end
 end


### PR DESCRIPTION
If any of the webhooks were lost because the site was unavailable
(networking issues, site update, etc) then the commit would not be
synced until another was pushed.

The new job ensures that all repositories are synced at least once an
hour.