### PR TITLE
DEV: Don't double-escape fancy title in commit approved notifications

### DIFF
--- a/assets/javascripts/discourse/initializers/init-code-review.js
+++ b/assets/javascripts/discourse/initializers/init-code-review.js
@@ -5,6 +5,7 @@ import DiscourseURL, { userPath } from "discourse/lib/url";
 import { findAll } from "discourse/models/login-method";
 import { computed } from "@ember/object";
 import I18n from "I18n";
+import { htmlSafe } from "@ember/template";
 
 const PLUGIN_ID = "discourse-code-review";
 
@@ -221,11 +222,10 @@ function initialize(api) {
                 }
               );
             } else {
-              return I18n.t(
-                "notifications.code_review.commit_approved.single",
-                {
+              return htmlSafe(
+                I18n.t("notifications.code_review.commit_approved.single", {
                   topicTitle: this.notification.fancy_title,
-                }
+                })
               );
             }
           }

--- a/test/javascripts/acceptance/commit-approved-notifications-test.js
+++ b/test/javascripts/acceptance/commit-approved-notifications-test.js
@@ -19,8 +19,8 @@ acceptance("Discourse Code Review - Notifications", function (needs) {
             created_at: "2001-10-17 15:41:10 UTC",
             post_number: 1,
             topic_id: 883,
-            fancy_title: "Commit #1",
-            slug: "commit-1",
+            fancy_title: "Osama's commit #1",
+            slug: "osama-s-commit-1",
             data: {
               num_approved_commits: 1,
             },
@@ -57,12 +57,12 @@ acceptance("Discourse Code Review - Notifications", function (needs) {
     assert.strictEqual(
       notifications[0].textContent.replaceAll(/\s+/g, " ").trim(),
       I18n.t("notifications.code_review.commit_approved.single", {
-        topicTitle: "Commit #1",
+        topicTitle: "Osama's commit #1",
       }),
       "notification for a single commit approval has the right content"
     );
     assert.ok(
-      notifications[0].href.endsWith("/t/commit-1/883"),
+      notifications[0].href.endsWith("/t/osama-s-commit-1/883"),
       "notification for a single commit approval links to the topic"
     );
     assert.ok(


### PR DESCRIPTION
`fancy_title` is sanitized/escaped by the server and is safe to render as HTML, so can opt-out of escaping it when it's rendered inside notifications in the experimental user menu to avoid characters like `'><&` getting incorrectly escaped.

Follow-up to https://github.com/discourse/discourse-code-review/commit/191af9e9e3efa83835751ef952a4a67ef915cfa0.