### PR TITLE
DEV: Temporarily skip two tests

### DIFF
--- a/test/javascripts/acceptance/admin-webhook-configuration-test.js
+++ b/test/javascripts/acceptance/admin-webhook-configuration-test.js
@@ -5,7 +5,7 @@ import {
   query,
 } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
-import { test } from "qunit";
+import { skip, test } from "qunit";
 
 const restPrefix = "/admin/plugins/code-review";
 
@@ -134,7 +134,7 @@ acceptance("GitHub Webhook Configuration - Repo List Error", function (needs) {
     });
   });
 
-  test("Should show an error message", async (assert) => {
+  skip("Should show an error message", async (assert) => {
     await visit("/admin/plugins/code-review");
     assert.equal(query(".modal-body").innerText, "credential error");
     await click(".modal-footer .btn-primary");
@@ -167,8 +167,9 @@ acceptance(
       );
     });
 
-    test("Should show an error message", async (assert) => {
+    skip("Should show an error message", async (assert) => {
       await visit("/admin/plugins/code-review");
+      pauseTest();
       assert.equal(query(".modal-body").innerText, "permissions error");
       await click(".modal-footer .btn-primary");
       assert.ok(exists(".code-review-configure-webhooks-button:disabled"));

--- a/test/javascripts/acceptance/admin-webhook-configuration-test.js
+++ b/test/javascripts/acceptance/admin-webhook-configuration-test.js
@@ -169,7 +169,6 @@ acceptance(
 
     skip("Should show an error message", async (assert) => {
       await visit("/admin/plugins/code-review");
-      pauseTest();
       assert.equal(query(".modal-body").innerText, "permissions error");
       await click(".modal-footer .btn-primary");
       assert.ok(exists(".code-review-configure-webhooks-button:disabled"));


### PR DESCRIPTION
These tests rely on a dialog in core that is about to change in https://github.com/discourse/discourse/pull/18292. So, to get stuff passing in CI and builds, I'm following this process: 

- skipping the tests (this PR)
- getting the core PR to ✅ in CI
- merging core PR
- reverting the skip and adjusting the test in code-review