### PR TITLE
UX: Remove unnecessary `li` tag for user-activity-bottom plugin outlet

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/user-activity-bottom/approval-given-button.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-activity-bottom/approval-given-button.hbs
@@ -1,5 +1,3 @@
-<li>
-  {{#link-to "userActivity.approval-given"}}
-    {{i18n "code_review.approval_given"}}
-  {{/link-to}}
-</li>
+{{#link-to "userActivity.approval-given"}}
+  {{i18n "code_review.approval_given"}}
+{{/link-to}}

--- a/assets/javascripts/discourse/templates/connectors/user-activity-bottom/approval-pending-button.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-activity-bottom/approval-pending-button.hbs
@@ -1,5 +1,3 @@
-<li>
-  {{#link-to "userActivity.approval-pending"}}
-    {{i18n "code_review.approval_pending"}}
-  {{/link-to}}
-</li>
+{{#link-to "userActivity.approval-pending"}}
+  {{i18n "code_review.approval_pending"}}
+{{/link-to}}


### PR DESCRIPTION
The plugin outlet is already wrapped in a `li` tag

https://github.com/discourse/discourse/blob/c0037dc0f06f08bd050aedc8aad97d1f05b322ab/app/assets/javascripts/discourse/app/templates/user/activity.hbs#L69