### PR TITLE
FIX: Recreate repo category if it was deleted

### DIFF
--- a/lib/discourse_code_review/state/github_repo_categories.rb
+++ b/lib/discourse_code_review/state/github_repo_categories.rb
@@ -38,11 +38,11 @@ module DiscourseCodeReview
               existing_category_ids = Category.where(id: SiteSetting.default_categories_muted.split("|")).pluck(:id)
               SiteSetting.default_categories_muted = (existing_category_ids << category.id).join("|")
             end
-
-            repo_category = GithubRepoCategory.new(category_id: category.id)
           end
 
           if category
+            repo_category ||= GithubRepoCategory.new
+            repo_category.category_id = category.id
             repo_category.repo_id = repo_id
             repo_category.name = repo_name
             repo_category.save! if repo_category.changed?

--- a/plugin.rb
+++ b/plugin.rb
@@ -308,6 +308,10 @@ after_initialize do
     )
   end
 
+  Category.class_eval do
+    has_one :github_repo_category, class_name: 'DiscourseCodeReview::GithubRepoCategory', dependent: :destroy
+  end
+
   Topic.class_eval do
     has_one :code_review_commit_topic, class_name: 'DiscourseCodeReview::CommitTopic'
   end

--- a/spec/discourse_code_review/lib/state/github_repo_categories_spec.rb
+++ b/spec/discourse_code_review/lib/state/github_repo_categories_spec.rb
@@ -12,6 +12,17 @@ describe DiscourseCodeReview::State::GithubRepoCategories do
     }.to change { Category.count }.by(1)
   end
 
+  it "can recreate a category" do
+    expect {
+      c = described_class.ensure_category(repo_name: "repo-name", repo_id: 242)
+      c.destroy!
+      c = described_class.ensure_category(repo_name: "repo-name", repo_id: 242)
+      expect(c.name).to eq("repo-name")
+      expect(c.custom_fields[DiscourseCodeReview::State::GithubRepoCategories::GITHUB_REPO_ID]).to eq("242")
+      expect(c.custom_fields[DiscourseCodeReview::State::GithubRepoCategories::GITHUB_REPO_NAME]).to eq("repo-name")
+    }.to change { Category.count }.by(1)
+  end
+
   it "can use an existing category" do
     c = Fabricate(:category, name: "repo-name")
     DiscourseCodeReview::GithubRepoCategory.create!(category_id: c.id, name: 'repo-name')


### PR DESCRIPTION
This commit ensures the repository category is recreated if it was destroyed.