### PR TITLE
FIX: Update repository name when receiving webhook

### DIFF
--- a/app/controllers/discourse_code_review/code_review_controller.rb
+++ b/app/controllers/discourse_code_review/code_review_controller.rb
@@ -36,7 +36,12 @@ module DiscourseCodeReview
       if repo.present?
         repo_id = repo["id"]
         repo_name = repo["full_name"]
+
+        if repo_name.present? && repo_category = GithubRepoCategory.find_by(repo_id: repo_id)
+          repo_category.update!(name: repo_name)
+        end
       end
+
       Rails.logger.warn("repo_name is blank. #{params.to_json}") if repo_name.blank?
 
       if type == "commit_comment"

--- a/spec/requests/discourse_code_review/code_review_controller_spec.rb
+++ b/spec/requests/discourse_code_review/code_review_controller_spec.rb
@@ -69,6 +69,18 @@ describe DiscourseCodeReview::CodeReviewController do
         expect(Jobs::CodeReviewSyncPullRequest.jobs.count).to eq(1)
       end
     end
+
+    it "can rename github repositories" do
+      repo_category = DiscourseCodeReview::GithubRepoCategory.create!(repo_id: 1, name: 'old_name')
+
+      post '/code-review/webhook',
+        headers: { "HTTP_X_HUB_SIGNATURE" => "sha1=c060d3354194566f042ca8ba7eadf4ac9f87eeda" },
+        params: { repository: { id: 1, full_name: 'new_name' } }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq('"ok"')
+      expect(repo_category.reload.name).to eq('new_name')
+    end
   end
 
   context "when signed in as an admin" do


### PR DESCRIPTION
Using old repository names can lead to invalid GraphQL queries and result in errors.