### PR TITLE
DEV: Use jobs to process webhook payload

### DIFF
--- a/app/controllers/discourse_code_review/code_review_controller.rb
+++ b/app/controllers/discourse_code_review/code_review_controller.rb
@@ -55,22 +55,18 @@ module DiscourseCodeReview
         ::Jobs.enqueue_in(30.seconds, :code_review_sync_commits, repo_name: repo_name, repo_id: repo_id)
       end
 
-      if type == "commit_comment"
-        syncer = DiscourseCodeReview.github_pr_syncer
-        git_commit = params["comment"]["commit_id"]
-
-        syncer.sync_associated_pull_requests(repo_name, git_commit, repo_id: repo_id)
-      end
-
       if ["pull_request", "issue_comment", "pull_request_review", "pull_request_review_comment"].include? type
-        syncer = DiscourseCodeReview.github_pr_syncer
-
         issue_number =
           params['number'] ||
           (params['issue'] && params['issue']['number']) ||
           (params['pull_request'] && params['pull_request']['number'])
 
-        syncer.sync_pull_request(repo_name, issue_number, repo_id: repo_id)
+        ::Jobs.enqueue(
+          :code_review_sync_pull_request,
+          repo_name: repo_name,
+          issue_number: issue_number,
+          repo_id: repo_id
+        )
       end
 
       render plain: '"ok"'

--- a/app/jobs/regular/code_review_sync_commit_comments.rb
+++ b/app/jobs/regular/code_review_sync_commit_comments.rb
@@ -16,9 +16,12 @@ module Jobs
       client = DiscourseCodeReview.octokit_client
       github_commit_querier = DiscourseCodeReview.github_commit_querier
       repo = DiscourseCodeReview::GithubRepo.new(repo_name, client, github_commit_querier, repo_id: repo_id)
-      importer = DiscourseCodeReview::Importer.new(repo)
 
+      importer = DiscourseCodeReview::Importer.new(repo)
       importer.sync_commit_sha(commit_sha)
+
+      syncer = DiscourseCodeReview.github_pr_syncer
+      syncer.sync_associated_pull_requests(repo_name, commit_sha, repo_id: repo_id)
     end
   end
 end

--- a/app/jobs/regular/code_review_sync_pull_request.rb
+++ b/app/jobs/regular/code_review_sync_pull_request.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Jobs
+  class CodeReviewSyncPullRequest < ::Jobs::Base
+    def execute(args)
+      repo_name, issue_number, repo_id = args.values_at(:repo_name, :issue_number, :repo_id)
+
+      unless repo_name.kind_of?(String)
+        raise Discourse::InvalidParameters.new(:repo_name)
+      end
+
+      syncer = DiscourseCodeReview.github_pr_syncer
+      syncer.sync_pull_request(repo_name, issue_number, repo_id: repo_id)
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -178,6 +178,7 @@ after_initialize do
   require File.expand_path("../app/models/commit_topic.rb", __FILE__)
   require File.expand_path("../app/jobs/regular/code_review_sync_commits", __FILE__)
   require File.expand_path("../app/jobs/regular/code_review_sync_commit_comments", __FILE__)
+  require File.expand_path("../app/jobs/regular/code_review_sync_pull_request", __FILE__)
   require File.expand_path("../app/jobs/scheduled/code_review_sync_repos", __FILE__)
   require File.expand_path("../lib/enumerators", __FILE__)
   require File.expand_path("../lib/typed_data", __FILE__)


### PR DESCRIPTION
Processing webhooks can fail sometimes (GitHub API rate limits, networking issues, etc) and without a retry mechanism, the payload is lost and the event is not processed properly. Sidekiq provides automatic retry functionality that can be used to retry payload processing.