### PR TITLE
FIX: Retry after rate limit is lifted

### DIFF
--- a/app/jobs/regular/code_review_sync_commit_comments.rb
+++ b/app/jobs/regular/code_review_sync_commit_comments.rb
@@ -2,6 +2,8 @@
 
 module Jobs
   class CodeReviewSyncCommitComments < ::Jobs::Base
+    include OctokitRateLimitRetryMixin
+
     def execute(args)
       repo_name, commit_sha, repo_id = args.values_at(:repo_name, :commit_sha, :repo_id)
 

--- a/app/jobs/regular/code_review_sync_commits.rb
+++ b/app/jobs/regular/code_review_sync_commits.rb
@@ -2,7 +2,7 @@
 
 module Jobs
   class CodeReviewSyncCommits < ::Jobs::Base
-    sidekiq_options retry: false
+    include OctokitRateLimitRetryMixin
 
     def execute(args)
       unless args[:repo_name].kind_of?(String)

--- a/app/jobs/regular/code_review_sync_pull_request.rb
+++ b/app/jobs/regular/code_review_sync_pull_request.rb
@@ -2,6 +2,8 @@
 
 module Jobs
   class CodeReviewSyncPullRequest < ::Jobs::Base
+    include OctokitRateLimitRetryMixin
+
     def execute(args)
       repo_name, issue_number, repo_id = args.values_at(:repo_name, :issue_number, :repo_id)
 

--- a/lib/octokit_rate_limit_retry_mixin.rb
+++ b/lib/octokit_rate_limit_retry_mixin.rb
@@ -3,7 +3,7 @@
 module OctokitRateLimitRetryMixin
   def self.included(base)
     base.sidekiq_retry_in do |count, exception|
-      case exception.wrapped
+      case exception&.wrapped
       when Octokit::TooManyRequests
         rate_limit = DiscourseCodeReview.octokit_client.rate_limit
         rand(rate_limit.resets_in..(rate_limit.resets_in + 60))

--- a/lib/octokit_rate_limit_retry_mixin.rb
+++ b/lib/octokit_rate_limit_retry_mixin.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module OctokitRateLimitRetryMixin
+  def self.included(base)
+    base.sidekiq_retry_in do |count, exception|
+      case exception.wrapped
+      when Octokit::TooManyRequests
+        rate_limit = DiscourseCodeReview.octokit_client.rate_limit
+        rand(rate_limit.resets_in..(rate_limit.resets_in + 60))
+      else
+        # Retry only once in 30..90 seconds
+        count == 0 ? rand(30..90) : :discard
+      end
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -22,6 +22,7 @@ register_asset 'stylesheets/code_review.scss'
 register_svg_icon 'history'
 
 require File.expand_path("../lib/discourse_code_review/rake_tasks.rb", __FILE__)
+require File.expand_path("../lib/octokit_rate_limit_retry_mixin.rb", __FILE__)
 require File.expand_path("../lib/validators/parent_category_validator.rb", __FILE__)
 
 module HackGithubAuthenticator

--- a/spec/lib/octokit_rate_limit_retry_mixin_spec.rb
+++ b/spec/lib/octokit_rate_limit_retry_mixin_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe OctokitRateLimitRetryMixin do
+  describe 'sidekiq_retry_in' do
+    class TestJob < ::Jobs::Base
+      include OctokitRateLimitRetryMixin
+    end
+
+    let(:exception) { Jobs::HandledExceptionWrapper.new(Octokit::TooManyRequests.new) }
+
+    before do
+      stub_request(:get, "https://api.github.com/rate_limit")
+        .to_return(status: 200, body: "", headers: {
+          "X-RateLimit-Limit" => 1000,
+          "X-RateLimit-Remaining" => 0,
+          "X-RateLimit-Reset" => 60.minutes.from_now.to_i,
+          "X-RateLimit-Resource" => "core",
+          "X-RateLimit-Used" => 0,
+        })
+    end
+
+    it 'retries after rate limit expires' do
+      expect(TestJob.sidekiq_retry_in_block.call(0, exception)).to be >= 3600
+    end
+
+    it 'retries after rate limit expires again' do
+      expect(TestJob.sidekiq_retry_in_block.call(1, exception)).to be >= 3600
+    end
+
+    it 'retries once for other errors' do
+      expect(TestJob.sidekiq_retry_in_block.call(0, nil)).to be >= 30
+      expect(TestJob.sidekiq_retry_in_block.call(0, nil)).to be <= 90
+      expect(TestJob.sidekiq_retry_in_block.call(1, nil)).to eq(:discard)
+    end
+  end
+end


### PR DESCRIPTION
It used default Sidekiq logic which retries several times without taking into account GitHub API rate limit.