### PR TITLE
DEV: Fix flaky test

### DIFF
--- a/spec/lib/octokit_rate_limit_retry_mixin_spec.rb
+++ b/spec/lib/octokit_rate_limit_retry_mixin_spec.rb
@@ -15,7 +15,7 @@ describe OctokitRateLimitRetryMixin do
         .to_return(status: 200, body: "", headers: {
           "X-RateLimit-Limit" => 1000,
           "X-RateLimit-Remaining" => 0,
-          "X-RateLimit-Reset" => (now + 90.minutes).to_i,
+          "X-RateLimit-Reset" => 90.minutes.from_now.to_i,
           "X-RateLimit-Resource" => "core",
           "X-RateLimit-Used" => 0,
         })

--- a/spec/lib/octokit_rate_limit_retry_mixin_spec.rb
+++ b/spec/lib/octokit_rate_limit_retry_mixin_spec.rb
@@ -8,8 +8,6 @@ describe OctokitRateLimitRetryMixin do
       include OctokitRateLimitRetryMixin
     end
 
-    let(:now) { Time.zone.now }
-
     let(:exception) { Jobs::HandledExceptionWrapper.new(Octokit::TooManyRequests.new) }
 
     before do
@@ -17,27 +15,21 @@ describe OctokitRateLimitRetryMixin do
         .to_return(status: 200, body: "", headers: {
           "X-RateLimit-Limit" => 1000,
           "X-RateLimit-Remaining" => 0,
-          "X-RateLimit-Reset" => (now + 60.minutes).to_i,
+          "X-RateLimit-Reset" => (now + 90.minutes).to_i,
           "X-RateLimit-Resource" => "core",
           "X-RateLimit-Used" => 0,
         })
     end
 
     it 'retries after rate limit expires' do
-      freeze_time now
-
       expect(TestJob.sidekiq_retry_in_block.call(0, exception)).to be >= 3600
     end
 
     it 'retries after rate limit expires again' do
-      freeze_time now
-
       expect(TestJob.sidekiq_retry_in_block.call(1, exception)).to be >= 3600
     end
 
     it 'retries once for other errors' do
-      freeze_time now
-
       expect(TestJob.sidekiq_retry_in_block.call(0, nil)).to be >= 30
       expect(TestJob.sidekiq_retry_in_block.call(0, nil)).to be <= 90
       expect(TestJob.sidekiq_retry_in_block.call(1, nil)).to eq(:discard)


### PR DESCRIPTION
The fix in e1b5c441c1658624184d3d8f924a3e9312485ed8 does not work every time. This is a much more simple approach that should work everytime.