### PR TITLE
FIX: Stop trying to sync repositories that have moved

### DIFF
--- a/app/jobs/scheduled/code_review_sync_repos.rb
+++ b/app/jobs/scheduled/code_review_sync_repos.rb
@@ -5,7 +5,7 @@ module Jobs
     every 1.hour
 
     def execute(args = {})
-      DiscourseCodeReview::GithubRepoCategory.pluck(:name, :repo_id).each do |repo_name, repo_id|
+      DiscourseCodeReview::GithubRepoCategory.not_moved.pluck(:name, :repo_id).each do |repo_name, repo_id|
         ::Jobs.enqueue(
           :code_review_sync_commits,
           repo_name: repo_name,

--- a/app/models/github_repo_category.rb
+++ b/app/models/github_repo_category.rb
@@ -3,4 +3,8 @@
 class DiscourseCodeReview::GithubRepoCategory < ActiveRecord::Base
   self.table_name = 'code_review_github_repos'
   belongs_to :category
+
+  # "Moved" indicates that the repo has either been transferred or renamed.
+  #
+  scope :not_moved, -> { where.not(repo_id: nil) }
 end

--- a/spec/jobs/code_review_sync_repos_spec.rb
+++ b/spec/jobs/code_review_sync_repos_spec.rb
@@ -7,6 +7,10 @@ describe Jobs::CodeReviewSyncRepos, type: :code_review_integration do
   it 'schedules sync jobs for all repos' do
     DiscourseCodeReview::State::GithubRepoCategories.ensure_category(repo_name: 'discourse/discourse', repo_id: 42)
     DiscourseCodeReview::State::GithubRepoCategories.ensure_category(repo_name: 'discourse/discourse-code-review', repo_id: 43)
+    # Created ...
+    DiscourseCodeReview::State::GithubRepoCategories.ensure_category(repo_name: 'discourse/discourse-staff-notes', repo_id: 44)
+    # ... then moved.
+    DiscourseCodeReview::State::GithubRepoCategories.ensure_category(repo_name: 'discourse/discourse-staff-notes', repo_id: nil)
 
     expect { described_class.new.execute }
       .to change { Jobs::CodeReviewSyncCommits.jobs.count }.by(2)


### PR DESCRIPTION
### What is the problem?

We're seeing a lot of:

```
Job exception: undefined method `[]' for nil:NilClass
```

in logs. This is related to [this line](https://github.com/discourse/discourse-code-review/blob/main/lib/discourse_code_review/source/github_pr_querier.rb#L535) in `GithubPRQuerier#associated_pull_requests`, where we expect data of the form:

```json
{
  "data": {
    "resource": {
      "associatedPullRequests": {
        "nodes": [],
        "pageInfo": {
          "endCursor": null,
          "hasNextPage": false
        }
      }
    }
  }
}
```

but we're actually getting:

```json
{
  "data": {
    "resource": null
  }
}
```

### Why is this happening?

We currently iterate over known `GithubRepoCategory` records and schedule synchronisation for each.

When a repo is renamed, the old `GithubRepoCategory` remains, albeit with a `repo_id` that is null, alongside a new one. This causes a problem, as when we try to synchronise it, the repo isn't there. Note: synchronisation works fine for the "new" repo category in case of a rename.

When a repo is transferred, the old `GithubRepoCategory` also remains with a nulled `repo_id`, causing the same problem.

### How does this fix it?

This change fixes both cases by skipping repos that have been moved when scheduling the synchronisation.

### Alternatives considered

I briefly thought about something fancier, like listening for `repository` event webhooks, but it's unclear what action should be taken. After some consideration, I think the existing way is good, because it preserves history and the old category.