### PR TITLE
FIX: Don't associate pull requests from other repositories

### DIFF
--- a/lib/discourse_code_review/source/github_pr_querier.rb
+++ b/lib/discourse_code_review/source/github_pr_querier.rb
@@ -525,7 +525,7 @@ module DiscourseCodeReview
                 resource(url: #{uri.to_json}) {
                   ... on Commit {
                     associatedPullRequests(first: 100, after: #{cursor.to_json}) {
-                      nodes { number },
+                      nodes { number, repository { nameWithOwner } },
                       pageInfo { endCursor, hasNextPage }
                     }
                   }
@@ -542,6 +542,8 @@ module DiscourseCodeReview
         end
 
       prs.lazy.map { |pr|
+        owner, name = pr[:repository][:nameWithOwner].split("/")
+
         PullRequest.new(
           owner: owner,
           name: name,

--- a/lib/discourse_code_review/source/github_pr_service.rb
+++ b/lib/discourse_code_review/source/github_pr_service.rb
@@ -151,10 +151,16 @@ module DiscourseCodeReview
       pr_querier.pull_requests(owner, name)
     end
 
-    def associated_pull_requests(repo_name, commit_sha)
+    def associated_pull_requests(repo_name, commit_sha, include_external: false)
       owner, name = repo_name.split('/', 2)
 
-      pr_querier.associated_pull_requests(owner, name, commit_sha)
+      prs = pr_querier.associated_pull_requests(owner, name, commit_sha)
+
+      unless include_external
+        return prs.reject { |pr| external?(pr) }
+      end
+
+      prs
     end
 
     def pull_request_data(pr)
@@ -201,5 +207,9 @@ module DiscourseCodeReview
 
     attr_reader :pr_querier
     attr_reader :client
+
+    def external?(pr)
+      DiscourseCodeReview.github_organizations.exclude?(pr.owner)
+    end
   end
 end


### PR DESCRIPTION
### What is going wrong?

As part of synchronising repositories we look at associated pull requests of the commits in that repository. An assumption has been made here that those pull requests will belong to the same repository that we are synchronising.

This does not always hold true. In particular, when working with a forked repo and integrating upstream changes, the commits brought in may have associated pull requests from other repositories, causing synchronisation to fail because we can't find those pull requests.

### How does this fix it?

This change correctly assigns the owner and name of pull requests that are associated with commits, and excludes pull requests from external repositories by default.

### Considerations

There are three levels of abstraction that could be chosen here, in order from high level to low: `GithubPRSyncer`, `GithubPRService`, `GithubPRQuerier`.

I think `GithubPRQuerier` returning all data is conceptually correct. They are, after all, associated pull requests. If we do the filtering in `GithubPRSyncer` we'll need to do so in multiple call sites, including potential future ones. So in the end I went with doing this in the intermediate `GithubPRService`.

I decided to use an optional flag for this, even though there aren't any existing call sites that need the external ones, mostly to have more self-documenting code.