### PR TITLE
FIX: Lookup by repo_id only when it exists

### DIFF
--- a/lib/discourse_code_review/state/github_repo_categories.rb
+++ b/lib/discourse_code_review/state/github_repo_categories.rb
@@ -8,8 +8,7 @@ module DiscourseCodeReview
     class << self
       def ensure_category(repo_name:, repo_id: nil)
         ActiveRecord::Base.transaction(requires_new: true) do
-          repo_category = GithubRepoCategory.find_by(repo_id: repo_id)
-
+          repo_category = GithubRepoCategory.find_by(repo_id: repo_id) if repo_id.present?
           repo_category ||= GithubRepoCategory.find_by(name: repo_name)
 
           category = repo_category&.category


### PR DESCRIPTION
It used to fetch the first repository with no repo id associated.