### PR TITLE
FIX: Allow diff with first commit

### DIFF
--- a/lib/discourse_code_review/github_repo.rb
+++ b/lib/discourse_code_review/github_repo.rb
@@ -70,7 +70,7 @@ module DiscourseCodeReview
           line_content = nil
 
           if hash[:path].present? && hash[:position].present?
-            line_content = @git_repo.diff_excerpt(hash[:commit_id], hash[:path], hash[:position])
+            line_content = git_repo.diff_excerpt(hash[:commit_id], hash[:path], hash[:position])
           end
 
           login = hash[:user][:login] if hash[:user]

--- a/lib/discourse_code_review/source/git_repo.rb
+++ b/lib/discourse_code_review/source/git_repo.rb
@@ -2,6 +2,8 @@
 
 module DiscourseCodeReview::Source
   class GitRepo
+    EMPTY_TREE_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+
     Commit =
       TypedData::TypedStruct.new(
         oid: String,
@@ -44,8 +46,13 @@ module DiscourseCodeReview::Source
     end
 
     def diff_excerpt(ref, path, position)
-      lines =
-        @repo.diff("#{ref}^", ref, paths: [path]).patch.force_encoding(Encoding::UTF_8).split("\n")
+      diff = begin
+        @repo.diff("#{ref}^", ref, paths: [path])
+      rescue Rugged::InvalidError => ex
+        @repo.diff(EMPTY_TREE_SHA, ref, paths: [path])
+      end
+
+      lines = diff.patch.force_encoding(Encoding::UTF_8).split("\n")
 
       # -1 since lines use 1-based indexing
       # 5 lines in the preamble

--- a/lib/discourse_code_review/source/git_repo.rb
+++ b/lib/discourse_code_review/source/git_repo.rb
@@ -2,7 +2,7 @@
 
 module DiscourseCodeReview::Source
   class GitRepo
-    EMPTY_TREE_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+    EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
     Commit =
       TypedData::TypedStruct.new(
@@ -46,11 +46,12 @@ module DiscourseCodeReview::Source
     end
 
     def diff_excerpt(ref, path, position)
-      diff = begin
-        @repo.diff("#{ref}^", ref, paths: [path])
-      rescue Rugged::InvalidError => ex
-        @repo.diff(EMPTY_TREE_SHA, ref, paths: [path])
-      end
+      diff =
+        begin
+          @repo.diff("#{ref}^", ref, paths: [path])
+        rescue Rugged::InvalidError => ex
+          @repo.diff(EMPTY_TREE_SHA, ref, paths: [path])
+        end
 
       lines = diff.patch.force_encoding(Encoding::UTF_8).split("\n")
 

--- a/spec/discourse_code_review/lib/github_repo_spec.rb
+++ b/spec/discourse_code_review/lib/github_repo_spec.rb
@@ -136,5 +136,32 @@ module DiscourseCodeReview
 
       expect(repo.last_commit).to eq(sha)
     end
+
+    it "can get the diff of the first commit" do
+      sha = nil
+
+      Dir.chdir(origin_path) do
+        File.write("a", "hello")
+        `git add a`
+        `git commit -am 'first commit'`
+        File.write("a", "hello2")
+        `git commit -am 'second commit'`
+        File.write("a", "hello3")
+        `git commit -am 'third commit'`
+
+        sha = `git rev-list --max-parents=0 HEAD`.strip
+      end
+
+      repo = GithubRepo.new("fake_repo/fake_repo", nil, nil, repo_id: 24)
+      repo.stubs(:default_branch).returns("origin/main")
+      repo.path = checkout_path
+      repo.git_repo.fetch
+
+      expect(repo.git_repo.diff_excerpt(sha, 'a', 0)).to eq <<~DIFF.strip
+        @@ -0,0 +1 @@
+        +hello
+        \\ No newline at end of file
+      DIFF
+    end
   end
 end

--- a/spec/discourse_code_review/lib/github_repo_spec.rb
+++ b/spec/discourse_code_review/lib/github_repo_spec.rb
@@ -157,7 +157,7 @@ module DiscourseCodeReview
       repo.path = checkout_path
       repo.git_repo.fetch
 
-      expect(repo.git_repo.diff_excerpt(sha, 'a', 0)).to eq <<~DIFF.strip
+      expect(repo.git_repo.diff_excerpt(sha, "a", 0)).to eq <<~DIFF.strip
         @@ -0,0 +1 @@
         +hello
         \\ No newline at end of file


### PR DESCRIPTION
Diff did not work for the first commit because "HASH^" was not a valid reference.