### PR TITLE
DEV: Remove code_review_debug site setting

### DIFF
--- a/app/controllers/discourse_code_review/code_review_controller.rb
+++ b/app/controllers/discourse_code_review/code_review_controller.rb
@@ -61,11 +61,6 @@ module DiscourseCodeReview
       end
 
       if type == "push"
-        if SiteSetting.code_review_debug
-          Rails.logger.warn(
-            "[DiscourseCodeReview::CodeReviewController#webhook] Enuqueuing code_review_sync_commits with repo_name = #{repo_name}, repo_id = #{repo_id}",
-          )
-        end
         ::Jobs.enqueue_in(
           30.seconds,
           :code_review_sync_commits,

--- a/app/jobs/regular/code_review_sync_commits.rb
+++ b/app/jobs/regular/code_review_sync_commits.rb
@@ -34,11 +34,6 @@ module Jobs
 
       importer.sync_merged_commits do |commit_hash|
         if SiteSetting.code_review_approve_approved_prs
-          if SiteSetting.code_review_debug
-            Rails.logger.warn(
-              "[DiscourseCodeReview] [Jobs::CodeReviewSyncCommits] Applying Github approves for repo_name = #{repo_name}, commit_hash = #{commit_hash}",
-            )
-          end
           DiscourseCodeReview.github_pr_syncer.apply_github_approves(repo_name, commit_hash)
         end
       end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -40,6 +40,3 @@ plugins:
     type: category
     default: ""
     validator: "ParentCategoryValidator"
-  code_review_debug:
-    default: false
-    hidden: true

--- a/lib/discourse_code_review/github_pr_syncer.rb
+++ b/lib/discourse_code_review/github_pr_syncer.rb
@@ -71,7 +71,6 @@ module DiscourseCodeReview
           .joins(:code_review_commit_topic)
           .where(code_review_commit_topics: { sha: commit_hash })
           .first
-      end
       if topic
         pr_service
           .associated_pull_requests(repo_name, commit_hash)

--- a/lib/discourse_code_review/github_pr_syncer.rb
+++ b/lib/discourse_code_review/github_pr_syncer.rb
@@ -71,22 +71,12 @@ module DiscourseCodeReview
           .joins(:code_review_commit_topic)
           .where(code_review_commit_topics: { sha: commit_hash })
           .first
-
-      if SiteSetting.code_review_debug
-        Rails.logger.warn(
-          "[DiscourseCodeReview::GithubPRSyncer#apply_github_approves] [commit_hash = #{commit_hash}] topic.id = #{topic&.id}",
-        )
       end
       if topic
         pr_service
           .associated_pull_requests(repo_name, commit_hash)
           .each do |pr|
             merge_info = pr_service.merge_info(pr)
-            if SiteSetting.code_review_debug
-              Rails.logger.warn(
-                "[DiscourseCodeReview::GithubPRSyncer#apply_github_approves] [commit_hash = #{commit_hash}] pr = #{pr.to_json}, merge_info = #{merge_info}",
-              )
-            end
             if merge_info[:merged_by]
               merged_by = ensure_actor(merge_info[:merged_by])
 
@@ -98,11 +88,6 @@ module DiscourseCodeReview
                     SiteSetting.code_review_allow_self_approval || topic.user_id != user.id
                   end
 
-              if SiteSetting.code_review_debug
-                Rails.logger.warn(
-                  "[DiscourseCodeReview::GithubPRSyncer#apply_github_approves] [commit_hash = #{commit_hash}] approvers = #{approvers}",
-                )
-              end
               State::CommitApproval.approve(topic, approvers, pr: pr, merged_by: merged_by)
             end
           end


### PR DESCRIPTION
We used this to find out why some reviews were skipped, but lately, it has been working more reliably so it is no longer necessary.