### PR TITLE
FIX: approval topic lists should use username from route

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -28,3 +28,6 @@ en:
       This category was created to contain code reviews for %{repo_name}. Topics are created for each commit or pull request.
     bad_github_permissions_error: "There was an issue when fetching webhook data from GitHub. Please check your token configured in the code_review_github_token site setting has the 'repo' scope enabled. See https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps for more details."
     bad_github_credentials_error: "There was an issue with your GitHub credentials. Please check your code_review_github_token site setting and try again."
+  approval_list:
+    user_not_found: "Couldn't find user with username %{username}"
+

--- a/plugin.rb
+++ b/plugin.rb
@@ -300,19 +300,35 @@ after_initialize do
   end
 
   add_to_class(:list_controller, :approval_given) do
-    respond_with_list(
-      TopicQuery.new(current_user, tags: [SiteSetting.code_review_approved_tag]).list_topics_by(
-        current_user,
-      ),
-    )
+    author_user = User.find_by_username(params.require(:username))
+    if author_user.blank?
+      render json: {
+               errors: [I18n.t("approval_list.user_not_found", username: params[:username])],
+             },
+             status: 404
+    else
+      respond_with_list(
+        TopicQuery.new(current_user, tags: [SiteSetting.code_review_approved_tag]).list_topics_by(
+          author_user,
+        ),
+      )
+    end
   end
 
   add_to_class(:list_controller, :approval_pending) do
-    respond_with_list(
-      TopicQuery.new(current_user, tags: [SiteSetting.code_review_pending_tag]).list_topics_by(
-        current_user,
-      ),
-    )
+    author_user = User.find_by_username(params.require(:username))
+    if author_user.blank?
+      render json: {
+               errors: [I18n.t("approval_list.user_not_found", username: params[:username])],
+             },
+             status: 404
+    else
+      respond_with_list(
+        TopicQuery.new(current_user, tags: [SiteSetting.code_review_pending_tag]).list_topics_by(
+          author_user,
+        ),
+      )
+    end
   end
 
   Category.class_eval do

--- a/spec/requests/discourse_code_review/list_controller_spec.rb
+++ b/spec/requests/discourse_code_review/list_controller_spec.rb
@@ -3,22 +3,71 @@
 require "rails_helper"
 
 describe ListController do
+  fab!(:user) { Fabricate(:user, username: "t.testeur") }
+  fab!(:topic) { Fabricate(:topic, user: user) }
+  fab!(:pr) do
+    DiscourseCodeReview::PullRequest.new(owner: "owner", name: "name", issue_number: 101)
+  end
+  fab!(:approver) { Fabricate(:user, username: "approver-user") }
+  fab!(:merged_by) { Fabricate(:user) }
+  fab!(:pending_tag) { Fabricate(:tag, name: "pending") }
+  fab!(:pending_topic) { Fabricate(:topic, user: user, tags: [pending_tag]) }
+
   before do
-    user = Fabricate(:user, username: "t.testeur")
-    sign_in(user)
+    SiteSetting.code_review_enabled = true
+    sign_in(approver)
+
+    DiscourseCodeReview::State::CommitApproval.approve(
+      topic,
+      [approver, merged_by] * 2,
+      pr: pr,
+      merged_by: merged_by,
+    )
   end
 
   context "for approval-given route" do
-    it "handles periods in usernames" do
+    it "handles periods in usernames and lists topics authored by this username" do
       get "/topics/approval-given/t.testeur.json"
-      expect(response.status).to eq(204) # No content
+      topic_list = response.parsed_body["topic_list"]
+      expect(topic_list["topics"].size).to eq(1)
+      expect(topic_list["topics"][0]["id"]).to eq(topic.id)
+    end
+
+    it "lists only topics authored by the given username" do
+      get "/topics/approval-given/approver-user.json"
+      topic_list = response.parsed_body["topic_list"]
+      expect(topic_list["topics"].size).to eq(0)
+    end
+
+    it "returns a 404 for non-existing users" do
+      get "/topics/approval-given/non-existing-user.json"
+      expect(response.status).to eq(404)
+      expect(response.parsed_body["errors"]).to eq(
+        [I18n.t("approval_list.user_not_found", { username: "non-existing-user" })],
+      )
     end
   end
 
   context "for approval-pending route" do
-    it "handles periods in usernames" do
+    it "handles periods in usernames and lists topics authored by this username" do
       get "/topics/approval-pending/t.testeur.json"
-      expect(response.status).to eq(204) # No content
+      topic_list = response.parsed_body["topic_list"]
+      expect(topic_list["topics"].size).to eq(1)
+      expect(topic_list["topics"][0]["id"]).to eq(pending_topic.id)
+    end
+
+    it "lists only topics authored by the given username" do
+      get "/topics/approval-pending/approver-user.json"
+      topic_list = response.parsed_body["topic_list"]
+      expect(topic_list["topics"].size).to eq(0)
+    end
+
+    it "returns a 404 for non-existing users" do
+      get "/topics/approval-pending/non-existing-user.json"
+      expect(response.status).to eq(404)
+      expect(response.parsed_body["errors"]).to eq(
+        [I18n.t("approval_list.user_not_found", { username: "non-existing-user" })],
+      )
     end
   end
 end


### PR DESCRIPTION
The approval topic lists used by the "Approval given" and "Approval pending" tabs on a user profile were always returning the approval topics created by the currently logged in user, not from the user of the profile we're currently viewing.

This PR fixes it by listing topics authored by the currently viewed `username` instead, meaning the mentioned tabs now show all Approval and Pending code reviews from commits created by the requested `username`, as expected.