### PR TITLE
DEV: Change settings root from plugins: to discourse_code_review

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_code_review: "Discourse Code Review"
   js:
     action_codes:
       approved: "Approved"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_code_review:
   code_review_enabled: false
   code_review_allowed_groups:
     default: ""


### PR DESCRIPTION
This is so the plugins settings are better categorized in the site settings UI.