### PR TITLE
FIX: Don't error out when no associated PRs found

### DIFF
--- a/lib/discourse_code_review/source/github_pr_querier.rb
+++ b/lib/discourse_code_review/source/github_pr_querier.rb
@@ -446,7 +446,9 @@ module DiscourseCodeReview
               }
             ",
             )
-          data = response[:resource][:associatedPullRequests]
+          data = response.dig(:resource, :associatedPullRequests)
+
+          next { items: [], has_next_page: false } if data.blank?
 
           {
             items: data[:nodes],

--- a/spec/discourse_code_review/lib/github_pr_querier_spec.rb
+++ b/spec/discourse_code_review/lib/github_pr_querier_spec.rb
@@ -10,6 +10,14 @@ describe DiscourseCodeReview::Source::GithubPRQuerier, type: :code_review_integr
 
   let(:pr) { DiscourseCodeReview::PullRequest.new(owner: "owner", name: "name", issue_number: 100) }
 
+  describe "#associated_pull_requests" do
+    it "does not error out when the query finds nothing" do
+      GraphQLClientMock.any_instance.expects(:execute).returns({})
+
+      expect(pr_querier.associated_pull_requests(anything, anything, anything).to_a).to be_empty
+    end
+  end
+
   describe "#timeline" do
     let(:raw_events) do
       [


### PR DESCRIPTION
### What is the problem?

We're seeing the following errors in production logs:

```
Job exception: undefined method `[]' for nil:NilClass
```

coming from here:

```
github_pr_querier.rb:449:in `block in associated_pull_requests'
```

It seems there's an assumption that the query here will always return a result, which doesn't seem to hold.

### How does this fix it?

Break the assumption that there will be a response and properly handle the case where there's no resource.
