### PR TITLE
DEV: Replace deprecated min_trust_to_create_post

### DIFF
--- a/spec/requests/discourse_code_review/code_review_controller_spec.rb
+++ b/spec/requests/discourse_code_review/code_review_controller_spec.rb
@@ -278,7 +278,7 @@ describe DiscourseCodeReview::CodeReviewController do
       end
 
       it "notifies the topic author" do
-        author = Fabricate(:user)
+        author = Fabricate(:user, refresh_auto_groups: true)
         commit =
           create_post(
             user: author,
@@ -298,7 +298,7 @@ describe DiscourseCodeReview::CodeReviewController do
       end
 
       it "collapses commit approved notifications" do
-        author = Fabricate(:user)
+        author = Fabricate(:user, refresh_auto_groups: true)
 
         commit1 =
           create_post(
@@ -326,7 +326,7 @@ describe DiscourseCodeReview::CodeReviewController do
       end
 
       it 'doesn\'t disturb tracking users' do
-        author = Fabricate(:user)
+        author = Fabricate(:user, refresh_auto_groups: true)
         commit =
           create_post(
             user: author,


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/24740, `min_trust_to_create_topic` site setting was replaced by `create_topic_allowed_groups`. This PR replaces the former, deprecated one, with the latter.