### PR TITLE
DEV: Add refresh_auto_groups to test where it was missed out

### DIFF
--- a/spec/requests/discourse_code_review/code_review_controller_spec.rb
+++ b/spec/requests/discourse_code_review/code_review_controller_spec.rb
@@ -505,7 +505,7 @@ describe DiscourseCodeReview::CodeReviewController do
       default_allowed_group = Group.find_by(name: "staff")
       default_allowed_group.add(signed_in_user)
 
-      author = Fabricate(:admin)
+      author = Fabricate(:admin, refresh_auto_groups: true)
       default_allowed_group.add(author)
       commit =
         create_post(


### PR DESCRIPTION
### What is this?

Missed this one out, because the test is only run when `discourse-assign` is also present

Related: https://github.com/discourse/discourse/pull/24257