### PR TITLE
DEV: fix mobile spec

### DIFF
--- a/test/javascripts/acceptance/self-approve-mobile-test.js
+++ b/test/javascripts/acceptance/self-approve-mobile-test.js
@@ -35,7 +35,6 @@ acceptance("review mobile", function (needs) {
     updateCurrentUser({ id: 1 });
 
     await visit("/t/this-is-a-test-topic/9/1");
-    await click(".topic-footer-mobile-dropdown-trigger");
 
     assert.dom(".approve").doesNotExist();
   });


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/30242, the topic footer buttons mobile dropdown can be replaced by the button if there's only one option.

This fixes the spec that was clicking on the dropdown button before checking there was no assign option.