### PR TITLE
DEV: update deprecated icon name angle-double-right to angles-right

### DIFF
--- a/assets/javascripts/discourse/initializers/init-code-review.js
+++ b/assets/javascripts/discourse/initializers/init-code-review.js
@@ -128,7 +128,7 @@ function initialize(api) {
 
   api.registerTopicFooterButton({
     id: "skip",
-    icon: "angle-double-right",
+    icon: "angles-right",
     priority: 250,
     label: "code_review.skip.label",
     title: "code_review.skip.title",


### PR DESCRIPTION
This PR updates the deprecated `angle-double-right` icon name. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.