### PR TITLE
DEV: re-enable and update empty state test

### DIFF
--- a/test/javascripts/acceptance/user-activity-approval-given-test.js
+++ b/test/javascripts/acceptance/user-activity-approval-given-test.js
@@ -1,5 +1,5 @@
 import { visit } from "@ember/test-helpers";
-import { skip } from "qunit";
+import { test } from "qunit";
 import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
@@ -20,20 +20,18 @@ acceptance("User Activity / Approval Given - empty state", function (needs) {
     });
   });
 
-  /* disabled temporarily for core updates https://github.com/discourse/discourse/pull/33455 */
-
-  skip("Shows a blank page placeholder on own page", async function (assert) {
+  test("Shows a blank page placeholder on own page", async function (assert) {
     await visit(`/u/${currentUser}/activity/approval-given`);
     assert.equal(
-      query("div.empty-state span.empty-state-title").innerText,
+      query(".empty-state .empty-state-title").innerText,
       i18n("code_review.approval_given_empty_state_title")
     );
   });
 
-  skip("Shows a blank page placeholder on others' page", async function (assert) {
+  test("Shows a blank page placeholder on others' page", async function (assert) {
     await visit(`/u/${anotherUser}/activity/approval-given`);
     assert.equal(
-      query("div.empty-state span.empty-state-title").innerText,
+      query(".empty-state .empty-state-title").innerText,
       i18n("code_review.approval_given_empty_state_title_others", {
         username: anotherUser,
       })

--- a/test/javascripts/acceptance/user-activity-approval-given-test.js
+++ b/test/javascripts/acceptance/user-activity-approval-given-test.js
@@ -23,7 +23,7 @@ acceptance("User Activity / Approval Given - empty state", function (needs) {
   test("Shows a blank page placeholder on own page", async function (assert) {
     await visit(`/u/${currentUser}/activity/approval-given`);
     assert.equal(
-      query(".empty-state .empty-state-title").innerText,
+      query(".empty-state .empty-state__title").innerText,
       i18n("code_review.approval_given_empty_state_title")
     );
   });
@@ -31,7 +31,7 @@ acceptance("User Activity / Approval Given - empty state", function (needs) {
   test("Shows a blank page placeholder on others' page", async function (assert) {
     await visit(`/u/${anotherUser}/activity/approval-given`);
     assert.equal(
-      query(".empty-state .empty-state-title").innerText,
+      query(".empty-state .empty-state__title").innerText,
       i18n("code_review.approval_given_empty_state_title_others", {
         username: anotherUser,
       })

--- a/test/javascripts/acceptance/user-activity-approval-pending-test.js
+++ b/test/javascripts/acceptance/user-activity-approval-pending-test.js
@@ -1,5 +1,5 @@
 import { visit } from "@ember/test-helpers";
-import { skip } from "qunit";
+import { test } from "qunit";
 import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
@@ -20,18 +20,18 @@ acceptance("User Activity / Approval Pending - empty state", function (needs) {
     });
   });
 
-  skip("Shows a blank page placeholder on own page", async function (assert) {
+  test("Shows a blank page placeholder on own page", async function (assert) {
     await visit(`/u/${currentUser}/activity/approval-pending`);
     assert.equal(
-      query("div.empty-state span.empty-state-title").innerText,
+      query(".empty-state .empty-state-title").innerText,
       i18n("code_review.approval_pending_empty_state_title")
     );
   });
 
-  skip("Shows a blank page placeholder on others' page", async function (assert) {
+  test("Shows a blank page placeholder on others' page", async function (assert) {
     await visit(`/u/${anotherUser}/activity/approval-pending`);
     assert.equal(
-      query("div.empty-state span.empty-state-title").innerText,
+      query(".empty-state .empty-state-title").innerText,
       i18n("code_review.approval_pending_empty_state_title_others", {
         username: anotherUser,
       })

--- a/test/javascripts/acceptance/user-activity-approval-pending-test.js
+++ b/test/javascripts/acceptance/user-activity-approval-pending-test.js
@@ -23,7 +23,7 @@ acceptance("User Activity / Approval Pending - empty state", function (needs) {
   test("Shows a blank page placeholder on own page", async function (assert) {
     await visit(`/u/${currentUser}/activity/approval-pending`);
     assert.equal(
-      query(".empty-state .empty-state-title").innerText,
+      query(".empty-state .empty-state__title").innerText,
       i18n("code_review.approval_pending_empty_state_title")
     );
   });
@@ -31,7 +31,7 @@ acceptance("User Activity / Approval Pending - empty state", function (needs) {
   test("Shows a blank page placeholder on others' page", async function (assert) {
     await visit(`/u/${anotherUser}/activity/approval-pending`);
     assert.equal(
-      query(".empty-state .empty-state-title").innerText,
+      query(".empty-state .empty-state__title").innerText,
       i18n("code_review.approval_pending_empty_state_title_others", {
         username: anotherUser,
       })


### PR DESCRIPTION
Re-enables the tests disabled in https://github.com/discourse/discourse-code-review/commit/5a442d4393928f77c2a1723a98165b2b5417139d, now that https://github.com/discourse/discourse/pull/33455 has been merged