### PR TITLE
FEATURE: don't create staged users if enable_staged_users is disabled

### DIFF
--- a/spec/discourse_code_review/lib/github_user_syncer_spec.rb
+++ b/spec/discourse_code_review/lib/github_user_syncer_spec.rb
@@ -4,38 +4,58 @@ require "rails_helper"
 
 describe DiscourseCodeReview::GithubUserSyncer do
   describe "#ensure_user" do
-    it "uses name for username by default" do
-      name = "Bill"
-      email = "billgates@gmail.com"
+    context "when enable_staged_users is enabled" do
+      before { SiteSetting.enable_staged_users = true }
 
-      user_syncer = DiscourseCodeReview::GithubUserSyncer.new(nil)
-      user_syncer.ensure_user(name: name, email: email)
+      it "uses name for username by default" do
+        name = "Bill"
+        email = "billgates@gmail.com"
 
-      staged_user = User.find_by_email(email)
-      expect(staged_user.username).to eq(name)
+        user_syncer = DiscourseCodeReview::GithubUserSyncer.new(nil)
+        user_syncer.ensure_user(name: name, email: email)
+
+        staged_user = User.find_by_email(email)
+        expect(staged_user.username).to eq(name)
+        expect(staged_user).to be_staged
+      end
+
+      it "doesn't use email for username suggestions by default" do
+        email = "billgates@gmail.com"
+
+        user_syncer = DiscourseCodeReview::GithubUserSyncer.new(nil)
+        user_syncer.ensure_user(name: nil, email: email)
+
+        staged_user = User.find_by_email(email)
+        expect(staged_user.username).to eq("user1") # not "billgates" extracted from billgates@gmail.com
+      end
+
+      it "uses email for username if enabled and name consists entirely of disallowed characters" do
+        SiteSetting.use_email_for_username_and_name_suggestions = true
+        SiteSetting.unicode_usernames = false
+        name = "άκυρος"
+        email = "billgates@gmail.com"
+
+        user_syncer = DiscourseCodeReview::GithubUserSyncer.new(nil)
+        user_syncer.ensure_user(name: name, email: email)
+
+        staged_user = User.find_by_email(email)
+        expect(staged_user.username).to eq("billgates")
+      end
     end
 
-    it "doesn't use email for username suggestions by default" do
-      email = "billgates@gmail.com"
+    context "when enable_staged_users is disabled" do
+      before { SiteSetting.enable_staged_users = false }
 
-      user_syncer = DiscourseCodeReview::GithubUserSyncer.new(nil)
-      user_syncer.ensure_user(name: nil, email: email)
+      it "uses system user" do
+        name = "Bill"
+        email = "billgates@gmail.com"
 
-      staged_user = User.find_by_email(email)
-      expect(staged_user.username).to eq("user1") # not "billgates" extracted from billgates@gmail.com
-    end
-
-    it "uses email for username if enabled and name consists entirely of disallowed characters" do
-      SiteSetting.use_email_for_username_and_name_suggestions = true
-      SiteSetting.unicode_usernames = false
-      name = "άκυρος"
-      email = "billgates@gmail.com"
-
-      user_syncer = DiscourseCodeReview::GithubUserSyncer.new(nil)
-      user_syncer.ensure_user(name: name, email: email)
-
-      staged_user = User.find_by_email(email)
-      expect(staged_user.username).to eq("billgates")
+        user_syncer = DiscourseCodeReview::GithubUserSyncer.new(nil)
+        expect {
+          user = user_syncer.ensure_user(name: name, email: email)
+          expect(user).to eq(Discourse.system_user)
+        }.to_not change { User.count }
+      end
     end
   end
 end


### PR DESCRIPTION
internal ticket: t/122305/20

If staged users aren't allowed, use the system user when a real user doesn't match the commit.