### PR TITLE
FIX: Ensure review actions are only performable on visible topics

### DIFF
--- a/app/controllers/discourse_code_review/code_review_controller.rb
+++ b/app/controllers/discourse_code_review/code_review_controller.rb
@@ -93,7 +93,7 @@ module DiscourseCodeReview
     end
 
     def skip
-      topic = Topic.find_by(id: params[:topic_id])
+      topic = find_reviewable_commit_topic
 
       State::CommitApproval.skip(topic, current_user)
 
@@ -103,7 +103,7 @@ module DiscourseCodeReview
     def followup
       raise Discourse::InvalidAccess if !SiteSetting.code_review_allow_manual_followup
 
-      topic = Topic.find_by(id: params[:topic_id])
+      topic = find_reviewable_commit_topic
 
       State::CommitApproval.followup(topic, current_user)
 
@@ -113,33 +113,15 @@ module DiscourseCodeReview
     def followed_up
       raise Discourse::InvalidAccess if !SiteSetting.code_review_allow_manual_followup
 
-      topic = Topic.find_by(id: params[:topic_id])
+      topic = find_reviewable_commit_topic
 
-      tags = topic.tags.pluck(:name)
-
-      if tags.include?(SiteSetting.code_review_followup_tag)
-        tags -= [SiteSetting.code_review_approved_tag, SiteSetting.code_review_followup_tag]
-
-        tags << SiteSetting.code_review_pending_tag
-
-        DiscourseTagging.tag_topic_by_names(topic, Guardian.new(current_user), tags)
-
-        topic.add_moderator_post(
-          current_user,
-          nil,
-          bump: false,
-          post_type: Post.types[:small_action],
-          action_code: "followed_up",
-        )
-
-        DiscourseEvent.trigger(:unassign_topic, topic, current_user)
-      end
+      State::CommitApproval.complete_followup(topic, current_user)
 
       render json: success_json
     end
 
     def approve
-      topic = Topic.find_by(id: params[:topic_id])
+      topic = find_reviewable_commit_topic
 
       if !SiteSetting.code_review_allow_self_approval && topic.user_id == current_user.id
         raise Discourse::InvalidAccess
@@ -173,6 +155,14 @@ module DiscourseCodeReview
     end
 
     protected
+
+    def find_reviewable_commit_topic
+      topic = Topic.find_by(id: params[:topic_id])
+      guardian.ensure_can_see!(topic)
+      raise Discourse::InvalidAccess if !topic.code_review_commit_topic
+
+      topic
+    end
 
     def render_next_topic(category_id)
       category_filter_sql = <<~SQL

--- a/lib/discourse_code_review/state/commit_approval.rb
+++ b/lib/discourse_code_review/state/commit_approval.rb
@@ -6,6 +6,8 @@ module DiscourseCodeReview::State::CommitApproval
 
   class << self
     def skip(topic, user)
+      ensure_can_skip!(topic, user)
+
       if SiteSetting.code_review_skip_duration_minutes > 0
         DiscourseCodeReview::SkippedCodeReview.upsert(
           {
@@ -21,6 +23,8 @@ module DiscourseCodeReview::State::CommitApproval
     end
 
     def approve(topic, approvers, pr: nil, merged_by: nil)
+      approvers.each { |approver| ensure_can_approve!(topic, approver) }
+
       last_post = nil
       approvers.each { |approver| last_post = ensure_approved_post(topic, approver) }
 
@@ -38,14 +42,14 @@ module DiscourseCodeReview::State::CommitApproval
     end
 
     def followup(topic, actor)
-      tags = topic.tags.pluck(:name)
+      tags = ensure_can_followup!(topic, actor)
 
       if !tags.include?(SiteSetting.code_review_followup_tag)
         tags -= [SiteSetting.code_review_approved_tag, SiteSetting.code_review_pending_tag]
 
         tags << SiteSetting.code_review_followup_tag
 
-        DiscourseTagging.tag_topic_by_names(topic, Guardian.new(actor), tags)
+        DiscourseTagging.tag_topic_by_names(topic, actor.guardian, tags)
 
         topic.add_moderator_post(
           actor,
@@ -61,7 +65,28 @@ module DiscourseCodeReview::State::CommitApproval
       end
     end
 
+    def complete_followup(topic, actor)
+      tags = ensure_can_complete_followup!(topic, actor)
+
+      tags -= [SiteSetting.code_review_approved_tag, SiteSetting.code_review_followup_tag]
+      tags << SiteSetting.code_review_pending_tag
+
+      DiscourseTagging.tag_topic_by_names(topic, actor.guardian, tags)
+
+      topic.add_moderator_post(
+        actor,
+        nil,
+        bump: false,
+        post_type: Post.types[:small_action],
+        action_code: "followed_up",
+      )
+
+      DiscourseEvent.trigger(:unassign_topic, topic, actor)
+    end
+
     def followed_up(followee_topic, follower_topic)
+      ensure_can_auto_followed_up!(followee_topic, follower_topic)
+
       last_post =
         followee_topic.add_moderator_post(
           follower_topic.user,
@@ -86,6 +111,72 @@ module DiscourseCodeReview::State::CommitApproval
     end
 
     private
+
+    def ensure_can_skip!(topic, actor)
+      tags = ensure_can_review_commit_topic!(topic, actor)
+      raise Discourse::InvalidAccess if (tags & approvable_tags).empty?
+    end
+
+    def ensure_can_approve!(topic, actor)
+      tags = ensure_can_review_commit_topic!(topic, actor)
+      if !tags.include?(SiteSetting.code_review_approved_tag) && (tags & approvable_tags).empty?
+        raise Discourse::InvalidAccess
+      end
+
+      if !SiteSetting.code_review_allow_self_approval && topic.user_id == actor.id
+        raise Discourse::InvalidAccess
+      end
+    end
+
+    def ensure_can_followup!(topic, actor)
+      tags = ensure_can_review_commit_topic!(topic, actor)
+      if !tags.include?(SiteSetting.code_review_followup_tag) &&
+           (
+             tags & [SiteSetting.code_review_pending_tag, SiteSetting.code_review_approved_tag]
+           ).empty?
+        raise Discourse::InvalidAccess
+      end
+
+      tags
+    end
+
+    def ensure_can_complete_followup!(topic, actor)
+      tags = ensure_can_review_commit_topic!(topic, actor)
+      raise Discourse::InvalidAccess if actor.id != topic.user_id && !actor.staff?
+      raise Discourse::InvalidAccess if !tags.include?(SiteSetting.code_review_followup_tag)
+
+      tags
+    end
+
+    def ensure_can_auto_followed_up!(followee_topic, follower_topic)
+      raise Discourse::InvalidAccess if !follower_topic&.code_review_commit_topic
+
+      tags =
+        ensure_can_review_commit_topic!(
+          followee_topic,
+          follower_topic.user,
+          require_code_reviewer: false,
+        )
+      if !tags.include?(SiteSetting.code_review_approved_tag) && (tags & approvable_tags).empty?
+        raise Discourse::InvalidAccess
+      end
+    end
+
+    def ensure_can_review_commit_topic!(topic, actor, require_code_reviewer: true)
+      raise Discourse::InvalidAccess if !topic || !actor
+      if require_code_reviewer && !actor.admin? && !actor.can_review_code?
+        raise Discourse::InvalidAccess
+      end
+
+      actor.guardian.ensure_can_see!(topic)
+      raise Discourse::InvalidAccess if !topic.code_review_commit_topic
+
+      topic.tags.pluck(:name)
+    end
+
+    def approvable_tags
+      [SiteSetting.code_review_pending_tag, SiteSetting.code_review_followup_tag]
+    end
 
     def ensure_approved_post(topic, approver)
       DistributedMutex.synchronize("code-review:ensure-approved-post:#{topic.id}") do
@@ -121,7 +212,7 @@ module DiscourseCodeReview::State::CommitApproval
 
           tags << SiteSetting.code_review_approved_tag
 
-          DiscourseTagging.tag_topic_by_names(topic, Guardian.new(Discourse.system_user), tags)
+          DiscourseTagging.tag_topic_by_names(topic, Discourse.system_user.guardian, tags)
           already_approved = false
         end
       end

--- a/lib/discourse_code_review/state/commit_approval.rb
+++ b/lib/discourse_code_review/state/commit_approval.rb
@@ -85,8 +85,6 @@ module DiscourseCodeReview::State::CommitApproval
     end
 
     def followed_up(followee_topic, follower_topic)
-      ensure_can_auto_followed_up!(followee_topic, follower_topic)
-
       last_post =
         followee_topic.add_moderator_post(
           follower_topic.user,
@@ -146,20 +144,6 @@ module DiscourseCodeReview::State::CommitApproval
       raise Discourse::InvalidAccess if !tags.include?(SiteSetting.code_review_followup_tag)
 
       tags
-    end
-
-    def ensure_can_auto_followed_up!(followee_topic, follower_topic)
-      raise Discourse::InvalidAccess if !follower_topic&.code_review_commit_topic
-
-      tags =
-        ensure_can_review_commit_topic!(
-          followee_topic,
-          follower_topic.user,
-          require_code_reviewer: false,
-        )
-      if !tags.include?(SiteSetting.code_review_approved_tag) && (tags & approvable_tags).empty?
-        raise Discourse::InvalidAccess
-      end
     end
 
     def ensure_can_review_commit_topic!(topic, actor, require_code_reviewer: true)

--- a/spec/discourse_code_review/lib/state/commit_approval_spec.rb
+++ b/spec/discourse_code_review/lib/state/commit_approval_spec.rb
@@ -2,12 +2,17 @@
 
 module DiscourseCodeReview
   describe State::CommitApproval do
-    fab!(:topic)
+    fab!(:pending_tag) { Fabricate(:tag, name: SiteSetting.code_review_pending_tag) }
+    fab!(:topic) { Fabricate(:topic, tags: [pending_tag]) }
     fab!(:pr) do
       DiscourseCodeReview::PullRequest.new(owner: "owner", name: "name", issue_number: 101)
     end
-    fab!(:approver, :user)
-    fab!(:merged_by, :user)
+    fab!(:approver, :admin)
+    fab!(:merged_by, :admin)
+
+    before do
+      DiscourseCodeReview::CommitTopic.create!(topic_id: topic.id, sha: SecureRandom.hex(20))
+    end
 
     describe "#ensure_pr_merge_info_post" do
       it "does not consider duplicate approvers" do
@@ -24,11 +29,48 @@ module DiscourseCodeReview
       end
     end
 
+    describe ".followup" do
+      fab!(:reviewer_group, :group)
+      fab!(:actor, :user)
+      fab!(:private_group, :group)
+
+      fab!(:private_category) { Fabricate(:private_category, group: private_group) }
+
+      fab!(:private_topic) do
+        Fabricate(:topic, category: private_category, tags: [pending_tag], user: Fabricate(:admin))
+      end
+
+      before do
+        SiteSetting.code_review_allowed_groups = reviewer_group.id.to_s
+        SiteSetting.tagging_enabled = true
+        reviewer_group.add(actor)
+        DiscourseCodeReview::CommitTopic.create!(
+          topic_id: private_topic.id,
+          sha: SecureRandom.hex(20),
+        )
+      end
+
+      it "requires the actor to see the topic" do
+        expect(actor.guardian.can_see?(private_topic)).to eq(false)
+
+        expect { State::CommitApproval.followup(private_topic, actor) }.to raise_error(
+          Discourse::InvalidAccess,
+        )
+        expect(private_topic.reload.tags.pluck(:name)).to contain_exactly(
+          SiteSetting.code_review_pending_tag,
+        )
+      end
+    end
+
     describe "creates notifications upon approval" do
       before { SiteSetting.code_review_enabled = true }
 
       it "doesn't consolidate notifications if they were created more than 6 hours ago" do
-        second_topic = Fabricate(:topic, user: topic.user)
+        second_topic = Fabricate(:topic, tags: [pending_tag], user: topic.user)
+        DiscourseCodeReview::CommitTopic.create!(
+          topic_id: second_topic.id,
+          sha: SecureRandom.hex(20),
+        )
         second_pr =
           DiscourseCodeReview::PullRequest.new(owner: "owner", name: "name", issue_number: 102)
 

--- a/spec/requests/discourse_code_review/code_review_controller_spec.rb
+++ b/spec/requests/discourse_code_review/code_review_controller_spec.rb
@@ -3,6 +3,19 @@
 describe DiscourseCodeReview::CodeReviewController do
   fab!(:topic)
 
+  def create_commit_post(**args)
+    tag_names = args[:tags]
+
+    create_post(**args).tap do |post|
+      if tag_names.present?
+        DiscourseTagging.tag_topic_by_names(post.topic, Discourse.system_user.guardian, tag_names)
+        post.topic.reload
+      end
+
+      DiscourseCodeReview::CommitTopic.create!(topic_id: post.topic_id, sha: SecureRandom.hex(20))
+    end
+  end
+
   before_all do
     topic.upsert_custom_fields(DiscourseCodeReview::COMMIT_HASH => "6a5aecee1234")
     DiscourseCodeReview::CommitTopic.create!(topic_id: topic.id, sha: "6a5aecee1234")
@@ -20,6 +33,63 @@ describe DiscourseCodeReview::CodeReviewController do
       sign_in(Fabricate(:user))
       get "/code-review/redirect/6a5aecee"
       expect(response.status).to eq(403)
+    end
+  end
+
+  context "when signed in as a code reviewer" do
+    fab!(:reviewer_group, :group)
+    fab!(:reviewer, :user)
+    fab!(:private_group, :group)
+
+    fab!(:private_category) { Fabricate(:private_category, group: private_group) }
+
+    before do
+      SiteSetting.tagging_enabled = true
+      SiteSetting.code_review_allowed_groups = reviewer_group.id.to_s
+      reviewer_group.add(reviewer)
+
+      sign_in(reviewer)
+    end
+
+    describe ".followed_up" do
+      it "blocks inaccessible commit topics" do
+        author = Fabricate(:admin)
+        commit =
+          create_commit_post(
+            category: private_category,
+            raw: "this is a fake commit",
+            tags: ["hi", SiteSetting.code_review_followup_tag],
+            user: author,
+          )
+        expect(reviewer.guardian.can_see?(commit.topic)).to eq(false)
+
+        post "/code-review/followed_up.json", params: { topic_id: commit.topic_id }
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
+        expect(commit.topic.reload.tags.pluck(:name)).to contain_exactly(
+          "hi",
+          SiteSetting.code_review_followup_tag,
+        )
+      end
+
+      it "blocks other reviewers from completing follow-ups" do
+        commit =
+          create_commit_post(
+            raw: "this is a fake commit",
+            tags: ["hi", SiteSetting.code_review_followup_tag],
+            user: Fabricate(:admin),
+          )
+
+        post "/code-review/followed_up.json", params: { topic_id: commit.topic_id }
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
+        expect(commit.topic.reload.tags.pluck(:name)).to contain_exactly(
+          "hi",
+          SiteSetting.code_review_followup_tag,
+        )
+      end
     end
   end
 
@@ -134,21 +204,21 @@ describe DiscourseCodeReview::CodeReviewController do
     describe ".skip" do
       it "allows users to skip commits" do
         commit1 =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit",
             tags: ["hi", SiteSetting.code_review_pending_tag],
             user: another_admin,
           )
 
         commit2 =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit",
             tags: ["hi", SiteSetting.code_review_pending_tag],
             user: another_admin,
           )
 
         commit3 =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit",
             tags: ["hi", SiteSetting.code_review_pending_tag],
             user: another_admin,
@@ -170,7 +240,7 @@ describe DiscourseCodeReview::CodeReviewController do
         SiteSetting.code_review_allow_self_approval = false
 
         commit =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit",
             user: signed_in_user,
             tags: ["hi", SiteSetting.code_review_pending_tag],
@@ -192,14 +262,14 @@ describe DiscourseCodeReview::CodeReviewController do
         )
 
         commit =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit",
             tags: [SiteSetting.code_review_pending_tag],
             user: admin2,
           )
 
         _muted_commit =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit 2",
             tags: [SiteSetting.code_review_pending_tag],
             category: muted_category.id,
@@ -217,14 +287,14 @@ describe DiscourseCodeReview::CodeReviewController do
         SiteSetting.code_review_allow_self_approval = true
 
         another_commit =
-          create_post(
+          create_commit_post(
             raw: "this is an old commit",
             tags: [SiteSetting.code_review_pending_tag],
             user: Fabricate(:admin, refresh_auto_groups: true),
           )
 
         commit =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit",
             user: signed_in_user,
             tags: ["hi", SiteSetting.code_review_pending_tag],
@@ -246,7 +316,7 @@ describe DiscourseCodeReview::CodeReviewController do
 
       it "does nothing when approving already approved posts" do
         commit =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit",
             tags: ["hi", SiteSetting.code_review_pending_tag],
           )
@@ -261,7 +331,7 @@ describe DiscourseCodeReview::CodeReviewController do
 
       it "allows multiple reviewers to approve a commit" do
         commit =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit",
             tags: ["hi", SiteSetting.code_review_pending_tag],
           )
@@ -280,7 +350,7 @@ describe DiscourseCodeReview::CodeReviewController do
       it "notifies the topic author" do
         author = Fabricate(:user, refresh_auto_groups: true)
         commit =
-          create_post(
+          create_commit_post(
             user: author,
             raw: "this is a fake commit",
             tags: ["hi", SiteSetting.code_review_pending_tag],
@@ -301,13 +371,13 @@ describe DiscourseCodeReview::CodeReviewController do
         author = Fabricate(:user, refresh_auto_groups: true)
 
         commit1 =
-          create_post(
+          create_commit_post(
             user: author,
             raw: "this is a fake commit",
             tags: ["hi", SiteSetting.code_review_pending_tag],
           )
         commit2 =
-          create_post(
+          create_commit_post(
             user: author,
             raw: "this is another fake commit",
             tags: ["hi", SiteSetting.code_review_pending_tag],
@@ -328,7 +398,7 @@ describe DiscourseCodeReview::CodeReviewController do
       it 'doesn\'t disturb tracking users' do
         author = Fabricate(:user, refresh_auto_groups: true)
         commit =
-          create_post(
+          create_commit_post(
             user: author,
             raw: "this is a fake commit",
             tags: ["hi", SiteSetting.code_review_pending_tag],
@@ -364,7 +434,7 @@ describe DiscourseCodeReview::CodeReviewController do
         SiteSetting.assign_enabled = true if defined?(TopicAssigner)
 
         commit =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit",
             user: signed_in_user,
             tags: ["hi", SiteSetting.code_review_approved_tag],
@@ -384,7 +454,7 @@ describe DiscourseCodeReview::CodeReviewController do
       it "gives invalid access when manual follow up is disabled" do
         SiteSetting.code_review_allow_manual_followup = false
         commit =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit",
             tags: ["hi", SiteSetting.code_review_pending_tag],
           )
@@ -394,7 +464,7 @@ describe DiscourseCodeReview::CodeReviewController do
 
       it "does nothing when following-up already followed-up posts" do
         commit =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit",
             tags: ["hi", SiteSetting.code_review_pending_tag],
           )
@@ -414,7 +484,7 @@ describe DiscourseCodeReview::CodeReviewController do
         SiteSetting.assign_enabled = true if defined?(TopicAssigner)
 
         commit =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit",
             user: signed_in_user,
             tags: ["hi", SiteSetting.code_review_followup_tag],
@@ -434,20 +504,20 @@ describe DiscourseCodeReview::CodeReviewController do
 
       it "prefers unread topics over read ones" do
         commit =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit",
             user: other_user,
             tags: ["hi", SiteSetting.code_review_pending_tag],
           )
         read_commit =
-          create_post(
+          create_commit_post(
             raw: "this is a read commit",
             user: other_user,
             tags: ["hi", SiteSetting.code_review_pending_tag],
             created_at: 1.hour.from_now,
           )
         unread_commit =
-          create_post(
+          create_commit_post(
             raw: "this is an unread commit",
             user: other_user,
             tags: ["hi", SiteSetting.code_review_pending_tag],
@@ -467,14 +537,14 @@ describe DiscourseCodeReview::CodeReviewController do
       it "will continue in the same category, even if muted" do
         category = Fabricate(:category)
         commit =
-          create_post(
+          create_commit_post(
             raw: "this is a fake commit",
             user: other_user,
             tags: ["hi", SiteSetting.code_review_pending_tag],
             category: category,
           )
         unread_commit =
-          create_post(
+          create_commit_post(
             raw: "this is an unread commit",
             user: other_user,
             tags: ["hi", SiteSetting.code_review_pending_tag],
@@ -508,7 +578,7 @@ describe DiscourseCodeReview::CodeReviewController do
       author = Fabricate(:admin, refresh_auto_groups: true)
       default_allowed_group.add(author)
       commit =
-        create_post(
+        create_commit_post(
           raw: "this is a fake commit",
           user: author,
           tags: ["hi", SiteSetting.code_review_pending_tag],

--- a/spec/requests/discourse_code_review/list_controller_spec.rb
+++ b/spec/requests/discourse_code_review/list_controller_spec.rb
@@ -2,18 +2,20 @@
 
 describe ListController do
   fab!(:user) { Fabricate(:user, username: "t.testeur") }
-  fab!(:topic) { Fabricate(:topic, user: user) }
+  fab!(:pending_tag) { Fabricate(:tag, name: "pending") }
+  fab!(:topic) { Fabricate(:topic, user: user, tags: [pending_tag]) }
   fab!(:pr) do
     DiscourseCodeReview::PullRequest.new(owner: "owner", name: "name", issue_number: 101)
   end
-  fab!(:approver) { Fabricate(:user, username: "approver-user") }
-  fab!(:merged_by, :user)
-  fab!(:pending_tag) { Fabricate(:tag, name: "pending") }
+  fab!(:approver) { Fabricate(:admin, username: "approver-user") }
+  fab!(:merged_by, :admin)
   fab!(:pending_topic) { Fabricate(:topic, user: user, tags: [pending_tag]) }
 
   before do
     SiteSetting.code_review_enabled = true
     sign_in(approver)
+
+    DiscourseCodeReview::CommitTopic.create!(topic_id: topic.id, sha: SecureRandom.hex(20))
 
     DiscourseCodeReview::State::CommitApproval.approve(
       topic,

--- a/spec/system/keyboard_shortcuts_spec.rb
+++ b/spec/system/keyboard_shortcuts_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe "Keyboard shortcuts" do
       fab!(:approved_tag) { Fabricate(:tag, name: "approved") }
       fab!(:pending_tag) { Fabricate(:tag, name: "pending") }
 
+      before do
+        DiscourseCodeReview::CommitTopic.create!(topic_id: topic.id, sha: SecureRandom.hex(20))
+      end
+
       context "when the commit is not approved" do
         before { topic.tags << pending_tag }
 


### PR DESCRIPTION
It's rare for code-review topics to be private, and it's even rarer for the review status to be considered sensitive. But even so, it makes sense to ensure reviewers can only change review status of topics they can see.