### PR TITLE
FIX: Scope next-topic lookup to topics the reviewer can see

### DIFF
--- a/app/controllers/discourse_code_review/code_review_controller.rb
+++ b/app/controllers/discourse_code_review/code_review_controller.rb
@@ -187,6 +187,9 @@ module DiscourseCodeReview
 
       next_topic =
         Topic
+          .visible
+          .listable_topics
+          .secured(guardian)
           .joins(:tags)
           .joins(
             "LEFT OUTER JOIN topic_users ON (topics.id = topic_users.topic_id AND topic_users.user_id = #{current_user.id})",

--- a/spec/requests/discourse_code_review/code_review_controller_spec.rb
+++ b/spec/requests/discourse_code_review/code_review_controller_spec.rb
@@ -91,6 +91,133 @@ describe DiscourseCodeReview::CodeReviewController do
         )
       end
     end
+
+    describe ".approve" do
+      it "does not return an inaccessible private topic as the next topic" do
+        public_commit =
+          create_commit_post(
+            raw: "this is a public commit",
+            tags: [SiteSetting.code_review_pending_tag],
+            user: Fabricate(:admin),
+          )
+        private_commit =
+          create_commit_post(
+            category: private_category,
+            raw: "this is a private commit",
+            tags: [SiteSetting.code_review_pending_tag],
+            user: Fabricate(:admin),
+          )
+        expect(reviewer.guardian.can_see?(private_commit.topic)).to eq(false)
+
+        post "/code-review/approve.json", params: { topic_id: public_commit.topic_id }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["next_topic_url"]).to be_nil
+        expect(response.body).not_to include(private_commit.topic.relative_url)
+      end
+
+      it "still returns the next accessible commit as the next topic" do
+        public_commit =
+          create_commit_post(
+            raw: "this is a public commit",
+            tags: [SiteSetting.code_review_pending_tag],
+            user: Fabricate(:admin),
+          )
+        other_public_commit =
+          create_commit_post(
+            raw: "this is another public commit",
+            tags: [SiteSetting.code_review_pending_tag],
+            user: Fabricate(:admin),
+          )
+
+        post "/code-review/approve.json", params: { topic_id: public_commit.topic_id }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["next_topic_url"]).to eq(other_public_commit.topic.relative_url)
+      end
+
+      it "returns a restricted-category commit the reviewer can access" do
+        private_group.add(reviewer)
+
+        public_commit =
+          create_commit_post(
+            raw: "this is a public commit",
+            tags: [SiteSetting.code_review_pending_tag],
+            user: Fabricate(:admin),
+          )
+        accessible_private_commit =
+          create_commit_post(
+            category: private_category,
+            raw: "this is an accessible private commit",
+            tags: [SiteSetting.code_review_pending_tag],
+            user: Fabricate(:admin),
+          )
+        expect(reviewer.guardian.can_see?(accessible_private_commit.topic)).to eq(true)
+
+        post "/code-review/approve.json", params: { topic_id: public_commit.topic_id }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["next_topic_url"]).to eq(
+          accessible_private_commit.topic.relative_url,
+        )
+      end
+
+      it "skips an inaccessible candidate and returns the next accessible one" do
+        target_category = Fabricate(:category)
+        approve_target =
+          create_commit_post(
+            category: target_category,
+            raw: "this is the approved commit",
+            tags: [SiteSetting.code_review_pending_tag],
+            user: Fabricate(:admin),
+          )
+        accessible_commit =
+          create_commit_post(
+            raw: "this is a public commit",
+            tags: [SiteSetting.code_review_pending_tag],
+            user: Fabricate(:admin),
+          )
+        inaccessible_commit =
+          create_commit_post(
+            category: private_category,
+            raw: "this is an inaccessible commit",
+            tags: [SiteSetting.code_review_pending_tag],
+            user: Fabricate(:admin),
+          )
+        expect(reviewer.guardian.can_see?(inaccessible_commit.topic)).to eq(false)
+
+        post "/code-review/approve.json", params: { topic_id: approve_target.topic_id }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["next_topic_url"]).to eq(accessible_commit.topic.relative_url)
+        expect(response.body).not_to include(inaccessible_commit.topic.relative_url)
+      end
+    end
+
+    describe ".skip" do
+      it "does not leak an inaccessible topic as the next topic" do
+        public_commit =
+          create_commit_post(
+            raw: "this is a public commit",
+            tags: [SiteSetting.code_review_pending_tag],
+            user: Fabricate(:admin),
+          )
+        private_commit =
+          create_commit_post(
+            category: private_category,
+            raw: "this is a private commit",
+            tags: [SiteSetting.code_review_pending_tag],
+            user: Fabricate(:admin),
+          )
+        expect(reviewer.guardian.can_see?(private_commit.topic)).to eq(false)
+
+        post "/code-review/skip.json", params: { topic_id: public_commit.topic_id }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["next_topic_url"]).not_to eq(private_commit.topic.relative_url)
+        expect(response.body).not_to include(private_commit.topic.relative_url)
+      end
+    end
   end
 
   describe "#webhook" do


### PR DESCRIPTION
### What

Follow-up to #276. That PR ensured review *actions* (skip/approve/followup/followed_up) can only be performed on topics the reviewer can see, but it left the `render_next_topic` query untouched.


In this pr we ensure that the next topic is also visible and listable 

relates to: patch-triage/1221       